### PR TITLE
WIP: feat: Runner wrap for UNIX

### DIFF
--- a/src/advancedcompilersettingsdialog.cpp
+++ b/src/advancedcompilersettingsdialog.cpp
@@ -43,6 +43,8 @@ AdvancedCompilerSettingsDialog::AdvancedCompilerSettingsDialog(QWidget *parent)
 	        &AdvancedCompilerSettingsDialog::memoryLimitRatioChanged);
 	connect(ui->disableMemoryLimit, &QCheckBox::stateChanged, this,
 	        &AdvancedCompilerSettingsDialog::disableMemoryLimitCheckChanged);
+	connect(ui->useRunnerWrap, &QCheckBox::stateChanged, this,
+	        &AdvancedCompilerSettingsDialog::useRunnerWrapCheckChanged);
 	connect(ui->configurationSelect, qOverload<int>(&QComboBox::currentIndexChanged), this,
 	        &AdvancedCompilerSettingsDialog::configurationIndexChanged);
 	connect(ui->configurationSelect, &QComboBox::editTextChanged, this,
@@ -70,6 +72,7 @@ void AdvancedCompilerSettingsDialog::resetEditCompiler(Compiler *compiler) {
 	ui->timeLimitRatio->setValue(editCompiler->getTimeLimitRatio());
 	ui->memoryLimitRatio->setValue(editCompiler->getMemoryLimitRatio());
 	ui->disableMemoryLimit->setChecked(editCompiler->getDisableMemoryLimitCheck());
+	ui->useRunnerWrap->setChecked(editCompiler->getUseRunnerWrap());
 	ui->memoryLimitRatio->setEnabled(! editCompiler->getDisableMemoryLimitCheck());
 	QStringList configurationNames = editCompiler->getConfigurationNames();
 	ui->configurationSelect->setEnabled(false);
@@ -231,6 +234,11 @@ void AdvancedCompilerSettingsDialog::disableMemoryLimitCheckChanged() {
 	editCompiler->setDisableMemoryLimitCheck(check);
 	ui->memoryLimitRatioLabel->setEnabled(! check);
 	ui->memoryLimitRatio->setEnabled(! check);
+}
+
+void AdvancedCompilerSettingsDialog::useRunnerWrapCheckChanged() {
+	bool check = ui->useRunnerWrap->isChecked();
+	editCompiler->setUseRunnerWrap(check);
 }
 
 void AdvancedCompilerSettingsDialog::configurationIndexChanged() {

--- a/src/advancedcompilersettingsdialog.h
+++ b/src/advancedcompilersettingsdialog.h
@@ -43,6 +43,7 @@ class AdvancedCompilerSettingsDialog : public QDialog {
 	void timeLimitRatioChanged();
 	void memoryLimitRatioChanged();
 	void disableMemoryLimitCheckChanged();
+	void useRunnerWrapCheckChanged();
 	void configurationIndexChanged();
 	void configurationTextChanged();
 	void deleteConfiguration();

--- a/src/base/compiler.cpp
+++ b/src/base/compiler.cpp
@@ -16,6 +16,7 @@ Compiler::Compiler(QObject *parent) : QObject(parent) {
 	timeLimitRatio = 1;
 	memoryLimitRatio = 1;
 	disableMemoryLimitCheck = false;
+	useRunnerWrap = false;
 }
 
 auto Compiler::getCompilerType() const -> Compiler::CompilerType { return compilerType; }
@@ -44,6 +45,8 @@ auto Compiler::getMemoryLimitRatio() const -> double { return memoryLimitRatio; 
 
 auto Compiler::getDisableMemoryLimitCheck() const -> bool { return disableMemoryLimitCheck; }
 
+auto Compiler::getUseRunnerWrap() const -> bool { return useRunnerWrap; }
+
 void Compiler::setCompilerType(Compiler::CompilerType type) { compilerType = type; }
 
 void Compiler::setCompilerName(const QString &name) { compilerName = name; }
@@ -67,6 +70,8 @@ void Compiler::setTimeLimitRatio(double ratio) { timeLimitRatio = ratio; }
 void Compiler::setMemoryLimitRatio(double ratio) { memoryLimitRatio = ratio; }
 
 void Compiler::setDisableMemoryLimitCheck(bool check) { disableMemoryLimitCheck = check; }
+
+void Compiler::setUseRunnerWrap(bool use) { useRunnerWrap = use; }
 
 void Compiler::addConfiguration(const QString &name, const QString &arguments1, const QString &arguments2) {
 	configurationNames.append(name);
@@ -114,6 +119,7 @@ void Compiler::copyFrom(Compiler *other) {
 	timeLimitRatio = other->getTimeLimitRatio();
 	memoryLimitRatio = other->getMemoryLimitRatio();
 	disableMemoryLimitCheck = other->getDisableMemoryLimitCheck();
+	useRunnerWrap = other->getUseRunnerWrap();
 }
 
 int Compiler::read(const QJsonObject &json) {
@@ -144,6 +150,7 @@ int Compiler::read(const QJsonObject &json) {
 	READ_JSON(json, timeLimitRatio);
 	READ_JSON(json, memoryLimitRatio);
 	READ_JSON(json, disableMemoryLimitCheck);
+	READ_JSON(json, useRunnerWrap);
 	return 0;
 }
 
@@ -164,4 +171,5 @@ void Compiler::write(QJsonObject &json) const {
 	WRITE_JSON(json, timeLimitRatio);          // double
 	WRITE_JSON(json, memoryLimitRatio);        // double
 	WRITE_JSON(json, disableMemoryLimitCheck); // bool
+	WRITE_JSON(json, useRunnerWrap);           // bool
 }

--- a/src/base/compiler.h
+++ b/src/base/compiler.h
@@ -34,6 +34,7 @@ class Compiler : public QObject {
 	double getTimeLimitRatio() const;
 	double getMemoryLimitRatio() const;
 	bool getDisableMemoryLimitCheck() const;
+	bool getUseRunnerWrap() const;
 
 	void setCompilerType(CompilerType);
 	void setCompilerName(const QString &);
@@ -45,6 +46,7 @@ class Compiler : public QObject {
 	void setTimeLimitRatio(double);
 	void setMemoryLimitRatio(double);
 	void setDisableMemoryLimitCheck(bool);
+	void setUseRunnerWrap(bool);
 
 	void addConfiguration(const QString &, const QString &, const QString &);
 	void setConfigName(int, const QString &);
@@ -71,4 +73,5 @@ class Compiler : public QObject {
 	double timeLimitRatio;
 	double memoryLimitRatio;
 	bool disableMemoryLimitCheck;
+	bool useRunnerWrap;
 };

--- a/src/base/settings.cpp
+++ b/src/base/settings.cpp
@@ -483,6 +483,7 @@ void Settings::saveSettings() {
 		settings.setValue("TimeLimitRatio", compilerList[i]->getTimeLimitRatio());
 		settings.setValue("MemoryLimitRatio", compilerList[i]->getMemoryLimitRatio());
 		settings.setValue("DisableMemoryLimitCheck", compilerList[i]->getDisableMemoryLimitCheck());
+		settings.setValue("UseRunnerWrap", compilerList[i]->getUseRunnerWrap());
 		QStringList configurationNames = compilerList[i]->getConfigurationNames();
 		QStringList compilerArguments = compilerList[i]->getCompilerArguments();
 		QStringList interpreterArguments = compilerList[i]->getInterpreterArguments();
@@ -609,6 +610,7 @@ void Settings::loadSettings() {
 		compiler->setTimeLimitRatio(settings.value("TimeLimitRatio").toDouble());
 		compiler->setMemoryLimitRatio(settings.value("MemoryLimitRatio").toDouble());
 		compiler->setDisableMemoryLimitCheck(settings.value("DisableMemoryLimitCheck").toBool());
+		compiler->setUseRunnerWrap(settings.value("UseRunnerWrap").toBool());
 		int configurationCount = settings.beginReadArray("Configuration");
 
 		for (int j = 0; j < configurationCount; j++) {

--- a/src/core/judgingthread.cpp
+++ b/src/core/judgingthread.cpp
@@ -933,7 +933,7 @@ void JudgingThread::runProgram() {
 	argumentsList << watcher.fileName();
 
 	if (useRunnerWrap) {
-		QString arg = QString("\"%1\" %2 --lemon-time-limit-ms=%3 --lemon-memory-limit-mb=%4")
+		QString arg = QString("\"%1\" %2 --lemon-time-limit-ms=%3 --lemon-memory-limit-mib=%4")
 		                  .arg(executableFile, arguments, QString::number(rawTimeLimit),
 		                       QString::number(rawMemoryLimit));
 		if (! task->getStandardInputCheck()) {
@@ -978,7 +978,7 @@ void JudgingThread::runProgram() {
 	QStringList argumentsList;
 
 	if (useRunnerWrap) {
-		QString arg = QString("\"%1\" %2 --lemon-time-limit-ms=%3 --lemon-memory-limit-mb=%4")
+		QString arg = QString("\"%1\" %2 --lemon-time-limit-ms=%3 --lemon-memory-limit-mib=%4")
 		                  .arg(executableFile, arguments, QString::number(rawTimeLimit),
 		                       QString::number(rawMemoryLimit));
 		if (! task->getStandardInputCheck()) {

--- a/src/core/judgingthread.h
+++ b/src/core/judgingthread.h
@@ -34,7 +34,10 @@ class JudgingThread : public QThread {
 	void setTask(Task *);
 	void setFullScore(int);
 	void setTimeLimit(int);
+	void setRawTimeLimit(int);
 	void setMemoryLimit(int);
+	void setRawMemoryLimit(int);
+	void setUseRunnerWrap(bool);
 	int getTimeUsed() const;
 	int getMemoryUsed() const;
 	int getScore() const;
@@ -63,7 +66,9 @@ class JudgingThread : public QThread {
 	int specialJudgeTimeLimit{};
 	int fullScore{};
 	int timeLimit{};
+	int rawTimeLimit{};
 	int memoryLimit{};
+	int rawMemoryLimit{};
 	int timeUsed;
 	int memoryUsed;
 	int score{};
@@ -71,6 +76,7 @@ class JudgingThread : public QThread {
 	ResultState result;
 	QString message;
 	bool stopJudging;
+	bool useRunnerWrap{};
 	void compareLineByLine(const QString &);
 	void compareIgnoreSpaces(const QString &);
 	void compareWithDiff(const QString &);

--- a/src/core/taskjudger.cpp
+++ b/src/core/taskjudger.cpp
@@ -149,6 +149,7 @@ auto TaskJudger::traditionalTaskPrepare() -> bool {
 		compilerTimeLimitRatio = i->getTimeLimitRatio();
 		compilerMemoryLimitRatio = i->getMemoryLimitRatio();
 		disableMemoryLimitCheck = i->getDisableMemoryLimitCheck();
+		useRunnerWrap = i->getUseRunnerWrap();
 		environment = i->getEnvironment();
 		QStringList values = QProcessEnvironment::systemEnvironment().toStringList();
 
@@ -478,11 +479,17 @@ int TaskJudger::judge() {
 			if (task->getTaskType() != Task::AnswersOnly) {
 				thread->setEnvironment(environment);
 				thread->setTimeLimit(qCeil(curTestCase->getTimeLimit() * compilerTimeLimitRatio));
+				thread->setRawTimeLimit(qCeil(curTestCase->getTimeLimit()));
 
 				if (disableMemoryLimitCheck) {
 					thread->setMemoryLimit(-1);
 				} else {
 					thread->setMemoryLimit(qCeil(curTestCase->getMemoryLimit() * compilerMemoryLimitRatio));
+				}
+				thread->setRawMemoryLimit(curTestCase->getMemoryLimit());
+
+				if (useRunnerWrap) {
+					thread->setUseRunnerWrap(true);
 				}
 			}
 			thread->start();

--- a/src/core/taskjudger.h
+++ b/src/core/taskjudger.h
@@ -52,6 +52,7 @@ class TaskJudger : public QObject {
 	double compilerTimeLimitRatio{};
 	double compilerMemoryLimitRatio{};
 	bool disableMemoryLimitCheck{};
+	bool useRunnerWrap{};
 	QProcessEnvironment environment;
 	QList<int> overallStatus;
 	QList<QList<int>> timeUsed;

--- a/src/forms/advancedcompilersettingsdialog.ui
+++ b/src/forms/advancedcompilersettingsdialog.ui
@@ -303,6 +303,13 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="0">
+       <widget class="QCheckBox" name="useRunnerWrap">
+        <property name="text">
+         <string>Use Runner Wrap</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="configurationSelect"/>
       </item>
@@ -418,6 +425,7 @@
   <tabstop>deleteConfigurationButton</tabstop>
   <tabstop>compilerArguments</tabstop>
   <tabstop>interpreterArguments</tabstop>
+  <tabstop>useRunnerWrap</tabstop>
   <tabstop>environmentVariablesButton</tabstop>
  </tabstops>
  <resources>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -453,6 +453,10 @@
         <translation>解释器参数</translation>
     </message>
     <message>
+        <source>Use Runner Wrap</source>
+        <translation>使用运行器包装</translation>
+    </message>
+    <message>
         <source>Environment Variables</source>
         <translation>环境变量</translation>
     </message>


### PR DESCRIPTION
## 这个 PR 做了什么

引入了一个叫「运行器包装」（Runner Wrap）的语言配置选项．

效果就是：在语言设置里边启用 Use Runner Wrap 后，运行选手代码编译出的最终文件（对于编译型语言，是二进制可执行文件；会于字节码语言，指的是类似执行 `java aaa.class`）的时候，把这个文件当成一个自定义运行器．

此时 Lemon 会以一种特殊的方式调用你的 runner，并通过命令行参数将评测所需的核心信息传递给它，例如：

- `--lemon-time-limit-ms=<时间限制>`：传递原始（只没被语言设置里的 ratio 缩放过的）时间限制（毫秒）．
- `--lemon-memory-limit-mib=<内存限制>`：传递原始内存限制（MiB）．
- `--lemon-input-file=<输入文件名>`：如果使用文件 I/O．
- `--lemon-output-file=<输出文件名>`：如果使用文件 I/O．

在这种模式下，自定义运行器负责：

- 启动用户程序．
- 严格监控其时间、内存使用．
- 在程序结束后，生成一个名为 `lemon_report.txt` 的报告文件．

Lemon 的 `JudgingThread` 不再解析 `watcher` 的标准输出，而是去读取并解析 `lemon_report.txt` 文件，从中获取最终的评测结果（如 `accepted`, `time_limit_exceeded`）、实际使用的时间和内存．

## runner 编写指南

Lemon 调用 runner 的格式是：

```bash
runner <ARGS> --lemon-time-limit-ms=<时间限制毫秒> --lemon-memory-limit-mib><内存限制 MiB> [--lemon-input-file=<如果设置不使用 stdin 就会传递这个 flag>] [--lemon-output-file=<如果设置不使用 stdout 就会传递这个 flag>]
```

<ARGS> 是你在语言设置里的「解释器执行命令」．

runner 负责调用选手程序，并控制其资源占用情况．

runner 需要将报告写入工作目录下 `lemon_report.txt` 的文件．首先输出一个字符串 `accepted`、`time_limit_exceeded`、`memory_limit_exceeded` 或 `runtime_error` 表示状态．接着输出时间（毫秒）、内存（byte）．之后的所有内容将会作为测试点报告的 message．

## 关于设计

- Q: 为啥不直接顶替原有的 watcher？
- A: 一方面是 Windows 那边的实现没有 watcher 这个东西，便于下一步支持 Windows．另一方面是有可能用户的 runner 可能实现的不是很好，导致自己死循环了或者异常占用资源，这时候需要 watcher 来当杀手锏用．

## 有什么用

第一个作用，可以配置一些特殊的题目测评流程．

第二个作用，针对一些解释型语言（主要是用虚拟机执行字节码的那一类语言），旧方案是直接测量虚拟机本身的运行时间合 使用的内存，新方案可以让 runner 测量内存，这样的话 runner 可以调用虚拟机的 API 直接报告选手程序用了多少时间内存，更加精确．

最重要的是：runner 可以自主报告给 lemon 程序的运行时间和内存，通过这种方式可以设置一个时间（毫秒）到 WASM tick 的比例，让 lemon 原生支持 [WASM Judge](https://yzy1.blog.uoj.ac/blog/9339)！

[此处](https://codeberg.org/aberter0x3f/wasm-judge-demo/src/branch/main/crates/runner-lemon/src/main.rs) 是一个参考 runner 实现．

## TODO

- Windows 支持
- 翻译文本

但是我长期不用 Windows，也没学过 Windows API．看不懂 Windows 的沙箱那边在做啥．感觉需要来个大佬帮我一下．
