### PR TITLE
Refactor ExportUtil

### DIFF
--- a/.github/workflows/windows-qt6.yml
+++ b/.github/workflows/windows-qt6.yml
@@ -82,8 +82,7 @@ jobs:
             -GNinja \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DLEMON_BUILD_INFO="Build for Windows" \
-            -DLEMON_BUILD_EXTRA_INFO="Build on Windows x64" \
-            -DENABLE_XLS_EXPORT=ON
+            -DLEMON_BUILD_EXTRA_INFO="Build on Windows x64"
           cmake --build . --parallel $(nproc)
       - name: Deploy Qt for tests
         shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,6 @@ option(EMBED_TRANSLATIONS "Embed translations" ON)
 LEMONLOG(EMBED_TRANSLATIONS)
 option(EMBED_DOCS "Embed documents" ON)
 LEMONLOG(EMBED_DOCS)
-option(ENABLE_XLS_EXPORT "XLS Result Export Support (Windows Only)" OFF)
-LEMONLOG(ENABLE_XLS_EXPORT)
 option(BUILD_DEB "Build deb format package" OFF)
 LEMONLOG(BUILD_DEB)
 option(BUILD_RPM "Build rpm format package" OFF)
@@ -286,12 +284,6 @@ else()
 endif()
 
 target_include_directories(lemon PUBLIC ${CMAKE_SOURCE_DIR}/src)
-
-if(WIN32 AND ENABLE_XLS_EXPORT)
-    find_package(${LEMON_QT_LIBNAME} COMPONENTS AxContainer REQUIRED)
-    list(APPEND LEMON_QT_LIBS ${LEMON_QT_LIBNAME}::AxContainer)
-    add_definitions(-DENABLE_XLS_EXPORT)
-endif()
 
 target_precompile_headers(lemon PUBLIC ${CMAKE_SOURCE_DIR}/src/pch.h)
 

--- a/resource.qrc
+++ b/resource.qrc
@@ -7,6 +7,9 @@
         <file>makespec/VERSIONSUFFIX</file>
         <file>assets/lemon-lime.ico</file>
     </qresource>
+    <qresource prefix="/export">
+        <file alias="export_template.html">src/component/exportutil/export_template.html</file>
+    </qresource>
     <qresource prefix="/icon">
         <file alias="icon.png">assets/icons/lemon-lime.png</file>
         <file alias="code-function.svg">assets/pics/code-function.svg</file>

--- a/src/component/exportutil/README.md
+++ b/src/component/exportutil/README.md
@@ -1,0 +1,143 @@
+# README
+
+### 顶级字段
+
+| 字段名        | 类型       | 说明             | 举例                                  |
+| ------------- | ---------- | ---------------- | ------------------------------------- |
+| `name`        | `string`   | 比赛名称         | `"contest"`                           |
+| `version`     | `string`   | LemonLime 版本   | `"Lemonlime Version 0.3.6.1:7545e02"` |
+| `task_names`  | `string[]` | 题目名称数组     | `["plus", "minus"]`                   |
+| `i18n`        | `object`   | i18n 字典        | 见下节                                |
+| `contestants` | `object[]` | 选手成绩数据数组 | 见下节                                |
+
+### i18n
+
+| 字段名        | 举例                                                      |
+| ------------- | --------------------------------------------------------- |
+| `rank_list`   | `"排名表"`                                                |
+| `hint`        | `"点击名字或单题分数跳转到详细信息。使用 LemonLime 评测"`       |
+| `rank`        | `"排名"`                                                  |
+| `name`        | `"名称"`                                                  |
+| `total`       | `"总分"`                                                  |
+| `contestant`  | `"选手"`                                                  |
+| `task`        | `"试题"`                                                  |
+| `source_file` | `"源程序："`                                              |
+| `no_source`   | `"未找到选手程序"`                                         |
+| `testcase`    | `"测试点"`                                                |
+| `input`       | `"输入文件"`                                              |
+| `result`      | `"测试结果"`                                              |
+| `time`        | `"运行用时"`                                              |
+| `memory`      | `"内存消耗"`                                              |
+| `score`       | `"得分"`                                                  |
+
+---
+
+### contestants 数组内对象
+
+| 字段名         | 类型       | 说明                 | 举例            |
+| -------------- | ---------- | -------------------- | --------------- |
+| `name`         | `string`   | 选手姓名             | `"Alice"`       |
+| `total_score`  | `number`   | 选手总分             | `200`           |
+| `total_bg`     | `string`   | 总分单元格背景 (HSL) | `"0, 70%, 90%"` |
+| `total_border` | `string`   | 总分单元格边框 (HSL) | `"0, 70%, 50%"` |
+| `tasks`        | `object[]` | 题目结果数组         | 见下节          |
+
+---
+
+### tasks 数组内对象
+
+| 字段名    | 类型       | 说明               | 举例              |
+| --------- | ---------- | ------------------ | ----------------- |
+| `score`   | `number`   | 该题单项得分       | `100`             |
+| `bg`      | `string`   | 该题得分背景 (HSL) | `"120, 30%, 60%"` |
+| `file`    | `string`   | 选手程序文件名（可选，若无该字段则表示找不到选手程序）     | `"plus.cpp"`      |
+| `details` | `object[]` | 测试点详情数组     | 见下节            |
+
+---
+
+### details 数组内对象
+
+| 字段名       | 类型     | 说明                                                 | 举例                           |
+| ------------ | -------- | ---------------------------------------------------- | ------------------------------ |
+| `label`      | `string` | 测试点编号或子任务信息，允许使用 `<br>`              | `"#2<br/>子任务依赖情况:Pure"` |
+| `row_span`   | `number` | 合并单元格行数（0 表示该行被合并，1 表示该行不合并） | `1`                            |
+| `input`      | `string` | 该测试点输入文件名                                   | `"plus2.in"`                   |
+| `result`     | `string` | 评测状态结果文字                                     | `"评测通过"`                   |
+| `time`       | `string` | 运行耗时字符串                                       | `"0.005 s"`                    |
+| `memory`     | `string` | 内存占用字符串                                       | `"5.34 MB"`                    |
+| `score`      | `number` | 该项得分                                             | `20`                           |
+| `full_score` | `number` | 该项满分                                             | `20`                           |
+| `bg`      | `string`   | 状态背景 (RGB) | `"rgb(192, 255, 192)"` |
+| `info` | `string` | 测评信息（可选） | `在第四行，读取到 123456，但期望 789123` |
+
+---
+
+### 示例 JSON
+
+以下 JSON 可用于调试模板渲染：
+
+```json
+{
+    "name": "example contest",
+    "version": "Lemonlime Version 0.3.6.1:7545e02",
+    "i18n": {
+        "rank_list": "排名表",
+        "hint": "点击名字或单题分数跳转到详细信息。使用 LemonLime 评测",
+        "rank": "排名",
+        "name": "名称",
+        "total": "总分",
+        "contestant": "选手",
+        "task": "试题",
+        "source_file": "源程序：",
+        "no_source": "未找到选手程序",
+        "testcase": "测试点",
+        "input": "输入文件",
+        "result": "测试结果",
+        "time": "运行用时",
+        "memory": "内存消耗",
+        "score": "得分"
+    },
+    "task_names": ["plus", "minus"],
+    "contestants": [
+        {
+            "name": "Alice",
+            "rank": 1,
+            "total_score": 150,
+            "total_bg": "120, 30%, 90%",
+            "total_border": "120, 30%, 50%",
+            "tasks": [
+                {
+                    "score": 100,
+                    "bg": "120, 30%, 70%",
+                    "file": "plus.cpp",
+                    "details": [
+                        { "label": "#1", "row_span": 1, "input": "plus1.in", "result": "评测通过", "time": "0.001 s", "memory": "1.2 MB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" },
+                        { "label": "#2", "row_span": 1, "input": "plus2.in", "result": "评测通过", "time": "0.002 s", "memory": "1.2 MB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" }
+                    ]
+                },
+                {
+                    "score": 50,
+                    "bg": "120,28.9006%,82.3499%",
+                    "file": "minus.cpp",
+                    "details": [
+                        { "label": "#1", "row_span": 1, "input": "minus1.in", "result": "评测通过", "time": "0.001 s", "memory": "1.2 MB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" },
+                        { "label": "#2<br>子任务依赖情况:Pure", "row_span": 2, "input": "minus2.in", "result": "答案错误", "time": "0.001 s", "memory": "2.0 MB", "score": 0, "full_score": 50, "bg": "rgb(255, 192, 192)", "info": "在第四行，读取到 123456，但期望 789123" },
+                        { "label": "", "row_span": 0, "input": "minus3.in", "result": "运行错误", "time": "0.001 s", "memory": "2.0 MB", "score": 0, "full_score": 50, "bg": "rgb(255, 192, 192)" }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Bob",
+            "rank": 2,
+            "total_score": 0,
+            "total_bg": "0, 0%, 90%",
+            "total_border": "0, 0%, 70%",
+            "tasks": [
+                { "score": 0, "bg": "0, 0%, 90%" },
+                { "score": 0, "bg": "0, 0%, 90%" }
+            ]
+        }
+    ]
+}
+```

--- a/src/component/exportutil/README.md
+++ b/src/component/exportutil/README.md
@@ -1,4 +1,10 @@
-# README
+# ExportUtil 导出模块
+
+本模块负责将比赛成绩导出为 HTML 或 CSV 格式。
+
+HTML 导出采用 **JSON + 模板** 方案：C++ 端通过 `buildExportJson()` 构建包含全部比赛数据的 JSON 对象，然后将其嵌入 `export_template.html` 中的 `%%DATA%%` 占位符，由浏览器端 JavaScript 完成页面渲染。这种方式将数据构造与页面展示解耦，C++ 代码只需关注 JSON 结构，无需拼接 HTML 字符串。
+
+以下是 JSON 数据的结构说明。
 
 ### 顶级字段
 
@@ -28,7 +34,8 @@
 | `result`      | `"测试结果"`                                              |
 | `time`        | `"运行用时"`                                              |
 | `memory`      | `"内存消耗"`                                              |
-| `score`       | `"得分"`                                                  |
+| `score`           | `"得分"`                                                  |
+| `return_to_top`   | `"返回顶部"`                                              |
 
 ---
 
@@ -37,6 +44,7 @@
 | 字段名         | 类型       | 说明                 | 举例            |
 | -------------- | ---------- | -------------------- | --------------- |
 | `name`         | `string`   | 选手姓名             | `"Alice"`       |
+| `rank`         | `number`   | 选手排名             | `1`             |
 | `total_score`  | `number`   | 选手总分             | `200`           |
 | `total_bg`     | `string`   | 总分单元格背景 (HSL) | `"0, 70%, 90%"` |
 | `total_border` | `string`   | 总分单元格边框 (HSL) | `"0, 70%, 50%"` |

--- a/src/component/exportutil/README.md
+++ b/src/component/exportutil/README.md
@@ -27,15 +27,13 @@ HTML 导出采用 JSON + 模板 方案：C++ 端通过 `buildExportJson()` 构�
 | `total`       | `"总分"`                                                  |
 | `contestant`  | `"选手"`                                                  |
 | `task`        | `"试题"`                                                  |
-| `source_file` | `"源程序："`                                              |
-| `no_source`   | `"未找到选手程序"`                                         |
 | `testcase`    | `"测试点"`                                                |
 | `input`       | `"输入文件"`                                              |
 | `result`      | `"测试结果"`                                              |
 | `time`        | `"运行用时"`                                              |
 | `memory`      | `"内存消耗"`                                              |
-| `score`           | `"得分"`                                                  |
-| `return_to_top`   | `"返回顶部"`                                              |
+| `score`       | `"得分"`                                                  |
+| `return_to_top` | `"返回顶部"`                                            |
 
 ---
 
@@ -54,12 +52,13 @@ HTML 导出采用 JSON + 模板 方案：C++ 端通过 `buildExportJson()` 构�
 
 ### tasks 数组内对象
 
-| 字段名    | 类型       | 说明               | 举例              |
-| --------- | ---------- | ------------------ | ----------------- |
-| `score`   | `number`   | 该题单项得分       | `100`             |
-| `bg`      | `string`   | 该题得分背景 (HSL) | `"120, 30%, 60%"` |
-| `file`    | `string`   | 选手程序文件名（可选，若无该字段则表示找不到选手程序）     | `"plus.cpp"`      |
-| `details` | `object[]` | 测试点详情数组     | 见下节            |
+| 字段名              | 类型       | 说明                       | 举例              |
+| ------------------- | ---------- | -------------------------- | ----------------- |
+| `score`             | `number`   | 该题单项得分               | `100`             |
+| `bg`                | `string`   | 该题得分背景 (HSL)         | `"120, 30%, 60%"` |
+| `info`              | `string`   | 评测状态/源文件信息       | `"源程序：plus.cpp"` |
+| `compile_message`   | `string`   | 编译错误详情（可选）       | `"error: expected ';'"` |
+| `details`           | `object[]` | 测试点详情数组             | 见下节            |
 
 ---
 
@@ -96,8 +95,6 @@ HTML 导出采用 JSON + 模板 方案：C++ 端通过 `buildExportJson()` 构�
         "total": "总分",
         "contestant": "选手",
         "task": "试题",
-        "source_file": "源程序：",
-        "no_source": "未找到选手程序",
         "testcase": "测试点",
         "input": "输入文件",
         "result": "测试结果",
@@ -117,7 +114,7 @@ HTML 导出采用 JSON + 模板 方案：C++ 端通过 `buildExportJson()` 构�
                 {
                     "score": 100,
                     "bg": "120, 30%, 70%",
-                    "file": "plus.cpp",
+                    "info": "源程序：plus.cpp",
                     "details": [
                         { "label": "#1", "row_span": 1, "input": "plus1.in", "result": "评测通过", "time": "0.001 s", "memory": "1.2 MiB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" },
                         { "label": "#2", "row_span": 1, "input": "plus2.in", "result": "评测通过", "time": "0.002 s", "memory": "1.2 MiB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" }
@@ -126,7 +123,7 @@ HTML 导出采用 JSON + 模板 方案：C++ 端通过 `buildExportJson()` 构�
                 {
                     "score": 50,
                     "bg": "120,28.9006%,82.3499%",
-                    "file": "minus.cpp",
+                    "info": "源程序：minus.cpp",
                     "details": [
                         { "label": "#1", "row_span": 1, "input": "minus1.in", "result": "评测通过", "time": "0.001 s", "memory": "1.2 MiB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" },
                         { "label": "#2<br>子任务依赖情况:Pure", "row_span": 2, "input": "minus2.in", "result": "答案错误", "time": "0.001 s", "memory": "2.0 MiB", "score": 0, "full_score": 50, "bg": "rgb(255, 192, 192)", "info": "在第四行，读取到 123456，但期望 789123" },
@@ -142,8 +139,8 @@ HTML 导出采用 JSON + 模板 方案：C++ 端通过 `buildExportJson()` 构�
             "total_bg": "0, 0%, 90%",
             "total_border": "0, 0%, 70%",
             "tasks": [
-                { "score": 0, "bg": "0, 0%, 90%" },
-                { "score": 0, "bg": "0, 0%, 90%" }
+                { "score": 0, "bg": "0, 0%, 90%", "info": "未测试" },
+                { "score": 0, "bg": "0, 0%, 90%", "info": "未测试" }
             ]
         }
     ]

--- a/src/component/exportutil/README.md
+++ b/src/component/exportutil/README.md
@@ -2,7 +2,7 @@
 
 本模块负责将比赛成绩导出为 HTML 或 CSV 格式。
 
-HTML 导出采用 **JSON + 模板** 方案：C++ 端通过 `buildExportJson()` 构建包含全部比赛数据的 JSON 对象，然后将其嵌入 `export_template.html` 中的 `%%DATA%%` 占位符，由浏览器端 JavaScript 完成页面渲染。这种方式将数据构造与页面展示解耦，C++ 代码只需关注 JSON 结构，无需拼接 HTML 字符串。
+HTML 导出采用 JSON + 模板 方案：C++ 端通过 `buildExportJson()` 构建包含全部比赛数据的 JSON 对象，然后将其嵌入 `export_template.html` 中的 `%%DATA%%` 占位符，由浏览器端 JavaScript 完成页面渲染。这种方式将数据构造与页面展示解耦，C++ 代码只需关注 JSON 结构，无需拼接 HTML 字符串。
 
 以下是 JSON 数据的结构说明。
 
@@ -72,7 +72,7 @@ HTML 导出采用 **JSON + 模板** 方案：C++ 端通过 `buildExportJson()` �
 | `input`      | `string` | 该测试点输入文件名                                   | `"plus2.in"`                   |
 | `result`     | `string` | 评测状态结果文字                                     | `"评测通过"`                   |
 | `time`       | `string` | 运行耗时字符串                                       | `"0.005 s"`                    |
-| `memory`     | `string` | 内存占用字符串                                       | `"5.34 MB"`                    |
+| `memory`     | `string` | 内存占用字符串                                       | `"5.34 MiB"`                   |
 | `score`      | `number` | 该项得分                                             | `20`                           |
 | `full_score` | `number` | 该项满分                                             | `20`                           |
 | `bg`      | `string`   | 状态背景 (RGB) | `"rgb(192, 255, 192)"` |
@@ -119,8 +119,8 @@ HTML 导出采用 **JSON + 模板** 方案：C++ 端通过 `buildExportJson()` �
                     "bg": "120, 30%, 70%",
                     "file": "plus.cpp",
                     "details": [
-                        { "label": "#1", "row_span": 1, "input": "plus1.in", "result": "评测通过", "time": "0.001 s", "memory": "1.2 MB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" },
-                        { "label": "#2", "row_span": 1, "input": "plus2.in", "result": "评测通过", "time": "0.002 s", "memory": "1.2 MB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" }
+                        { "label": "#1", "row_span": 1, "input": "plus1.in", "result": "评测通过", "time": "0.001 s", "memory": "1.2 MiB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" },
+                        { "label": "#2", "row_span": 1, "input": "plus2.in", "result": "评测通过", "time": "0.002 s", "memory": "1.2 MiB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" }
                     ]
                 },
                 {
@@ -128,9 +128,9 @@ HTML 导出采用 **JSON + 模板** 方案：C++ 端通过 `buildExportJson()` �
                     "bg": "120,28.9006%,82.3499%",
                     "file": "minus.cpp",
                     "details": [
-                        { "label": "#1", "row_span": 1, "input": "minus1.in", "result": "评测通过", "time": "0.001 s", "memory": "1.2 MB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" },
-                        { "label": "#2<br>子任务依赖情况:Pure", "row_span": 2, "input": "minus2.in", "result": "答案错误", "time": "0.001 s", "memory": "2.0 MB", "score": 0, "full_score": 50, "bg": "rgb(255, 192, 192)", "info": "在第四行，读取到 123456，但期望 789123" },
-                        { "label": "", "row_span": 0, "input": "minus3.in", "result": "运行错误", "time": "0.001 s", "memory": "2.0 MB", "score": 0, "full_score": 50, "bg": "rgb(255, 192, 192)" }
+                        { "label": "#1", "row_span": 1, "input": "minus1.in", "result": "评测通过", "time": "0.001 s", "memory": "1.2 MiB", "score": 50, "full_score": 50, "bg": "rgb(192, 255, 192)" },
+                        { "label": "#2<br>子任务依赖情况:Pure", "row_span": 2, "input": "minus2.in", "result": "答案错误", "time": "0.001 s", "memory": "2.0 MiB", "score": 0, "full_score": 50, "bg": "rgb(255, 192, 192)", "info": "在第四行，读取到 123456，但期望 789123" },
+                        { "label": "", "row_span": 0, "input": "minus3.in", "result": "运行错误", "time": "0.001 s", "memory": "2.0 MiB", "score": 0, "full_score": 50, "bg": "rgb(255, 192, 192)" }
                     ]
                 }
             ]

--- a/src/component/exportutil/export_template.html
+++ b/src/component/exportutil/export_template.html
@@ -1,0 +1,291 @@
+<html>
+<body>
+    <style>
+        table {
+            border-style: solid;
+        }
+        th, td {
+            padding-left: 1em;
+            padding-right: 1em;
+            white-space: nowrap;
+            text-align: center;
+            vertical-align: middle;
+        }
+        th {
+            border-style: none solid solid none;
+            border-width: 3px 3px;
+            border-color: #000;
+        }
+        td:not(.score) {
+            border-style: none solid solid none;
+            border-width: 1px 3px;
+            border-color: #ccc;
+        }
+        td.score {
+            border-radius: 5px;
+            font-weight: bold;
+        }
+        a {
+            text-decoration: none;
+        }
+        td > a:not(.info) {
+            color: black;
+        }
+        hr {
+            margin: 15px 0;
+        }
+    </style>
+    <script>
+        const data = %%DATA%%;
+
+        // 确定唯一 id
+        data.contestants.forEach((c, i) => c._id = `c${i}`);
+
+        document.title = `${data.name} : ${data.i18n.rank_list}`;
+
+        const desc = document.createElement('p');
+        desc.innerText = `${data.name} : ${data.i18n.rank_list}`;
+        document.body.append(desc);
+
+        const hint = document.createElement('p');
+        hint.innerText = data.i18n.hint;
+        document.body.append(hint);
+
+        const table = document.createElement('table');
+        const thead = document.createElement('thead');
+        const headerTr = document.createElement('tr');
+
+        // 默认按总分降序
+        let sortState = { key: 'total', taskIndex: null, asc: false };
+
+        const headers = [data.i18n.rank, data.i18n.name, data.i18n.total, ...data.task_names];
+
+        headers.forEach((text, idx) => {
+            const th = document.createElement('th');
+            th.innerText = text;
+
+            // 总分和每题列可点击排序
+            if (idx >= 2) {
+                const indicator = document.createElement('span');
+                indicator.className = 'sort-indicator';
+                indicator.style.visibility = 'hidden';
+                indicator.textContent = '▾';
+                th.appendChild(indicator);
+
+                th.style.cursor = 'pointer';
+                th.dataset.col = idx === 2 ? 'total' : 'task';
+                if (idx > 2) th.dataset.taskIndex = idx - 3;
+                th.onclick = () => {
+                    const col = th.dataset.col;
+                    if (col === 'total') {
+                        if (sortState.key === 'total') sortState.asc = !sortState.asc;
+                        else { sortState.key = 'total'; sortState.taskIndex = null; sortState.asc = false; }
+                    } else {
+                        const ti = parseInt(th.dataset.taskIndex, 10);
+                        if (sortState.key === 'task' && sortState.taskIndex === ti) sortState.asc = !sortState.asc;
+                        else { sortState.key = 'task'; sortState.taskIndex = ti; sortState.asc = false; }
+                    }
+                    renderTable();
+                };
+            }
+            headerTr.append(th);
+        });
+        thead.append(headerTr);
+        table.append(thead);
+
+        const tbody = document.createElement('tbody');
+        table.append(tbody);
+        document.body.append(table);
+
+        function clearChildren(el) {
+            while (el.firstChild) el.removeChild(el.firstChild);
+        }
+
+        function updateHeaderIndicators() {
+            const ths = thead.querySelectorAll('th');
+            ths.forEach((th, idx) => {
+                const indicator = th.querySelector('.sort-indicator');
+                if (!indicator) return;
+
+                if (idx >= 2) {
+                    const col = th.dataset.col;
+                    if (col === 'total' && sortState.key === 'total') {
+                        indicator.textContent = sortState.asc ? '▴' : '▾';
+                        indicator.style.visibility = 'visible';
+                    } else if (col === 'task') {
+                        const ti = parseInt(th.dataset.taskIndex, 10);
+                        if (sortState.key === 'task' && sortState.taskIndex === ti) {
+                            indicator.textContent = sortState.asc ? '▴' : '▾';
+                            indicator.style.visibility = 'visible';
+                        } else {
+                            indicator.style.visibility = 'hidden';
+                        }
+                    } else {
+                        indicator.style.visibility = 'hidden';
+                    }
+                } else {
+                    indicator.style.visibility = 'hidden';
+                }
+            });
+        }
+
+        function compareBy(a, b) {
+            let va, vb;
+            if (sortState.key === 'total') {
+                va = a.total_score || 0;
+                vb = b.total_score || 0;
+            } else {
+                const ti = sortState.taskIndex;
+                va = (a.tasks && a.tasks[ti]) ? (a.tasks[ti].score || 0) : 0;
+                vb = (b.tasks && b.tasks[ti]) ? (b.tasks[ti].score || 0) : 0;
+            }
+            if (va !== vb) return sortState.asc ? va - vb : vb - va;
+            if ((a.total_score || 0) !== (b.total_score || 0)) return (b.total_score || 0) - (a.total_score || 0);
+            return (a.rank || 0) - (b.rank || 0);
+        }
+
+        function renderTable() {
+            clearChildren(tbody);
+            updateHeaderIndicators();
+
+            const sorted = data.contestants.slice().sort(compareBy);
+
+            sorted.forEach((c) => {
+                const tr = document.createElement('tr');
+
+                // 排名
+                const rankTd = document.createElement('td');
+                const rankA = document.createElement('a');
+                rankA.innerText = c.rank;
+                rankA.href = `#${c._id}`;
+                rankTd.append(rankA);
+                tr.append(rankTd);
+
+                // 名称
+                const nameTd = document.createElement('td');
+                const nameA = document.createElement('a');
+                nameA.innerText = c.name;
+                nameA.href = `#${c._id}`;
+                nameTd.append(nameA);
+                tr.append(nameTd);
+
+                // 总分
+                const totalTd = document.createElement('td');
+                const aTotal = document.createElement('a');
+                aTotal.innerText = c.total_score;
+                aTotal.href = `#${c._id}`;
+                totalTd.append(aTotal);
+                totalTd.classList.add('score');
+                if (c.total_bg) totalTd.style.background = `hsl(${c.total_bg})`;
+                if (c.total_border) totalTd.style.border = `2px solid hsl(${c.total_border})`;
+                tr.append(totalTd);
+
+                // 每题分数
+                (c.tasks || []).forEach((t, j) => {
+                    const td = document.createElement('td');
+                    const a = document.createElement('a');
+                    a.innerText = t.score;
+                    a.href = `#${c._id}t${j}`;
+                    td.append(a);
+                    td.classList.add('score');
+                    if (t.bg) td.style.background = `hsl(${t.bg})`;
+                    tr.append(td);
+                });
+
+                tbody.append(tr);
+            });
+        }
+
+        // 详情区
+        data.contestants.forEach((c, i) => {
+            const hr = document.createElement('hr');
+            hr.id = c._id;
+            document.body.append(hr);
+
+            const contestantP = document.createElement('p');
+            contestantP.innerText = `${data.i18n.contestant} : ${c.name}`;
+            document.body.append(contestantP);
+
+            (c.tasks || []).forEach((t, j) => {
+                const taskContainer = document.createElement('div');
+                taskContainer.id = `${c._id}t${j}`;
+
+                const taskH3 = document.createElement('h3');
+                taskH3.innerText = `${data.i18n.task} ${data.task_names[j]}`;
+                taskContainer.append(taskH3);
+
+                const fileP = document.createElement('p');
+                fileP.innerText = t.file ? `${data.i18n.source_file}${t.file}` : data.i18n.no_source;
+                taskContainer.append(fileP);
+
+                if (t.details && t.details.length > 0) {
+                    const detailTable = document.createElement('table');
+                    const dThead = document.createElement('thead');
+                    const dHeaderTr = document.createElement('tr');
+                    [data.i18n.testcase, data.i18n.input, data.i18n.result, data.i18n.time, data.i18n.memory, data.i18n.score].forEach(text => {
+                        const th = document.createElement('th');
+                        th.innerText = text;
+                        dHeaderTr.append(th);
+                    });
+                    dThead.append(dHeaderTr);
+                    detailTable.append(dThead);
+
+                    const dTbody = document.createElement('tbody');
+                    t.details.forEach(d => {
+                        const dTr = document.createElement('tr');
+                        if (d.row_span > 0) {
+                            const labelTd = document.createElement('td');
+                            labelTd.rowSpan = d.row_span;
+                            labelTd.innerHTML = d.label;
+                            dTr.append(labelTd);
+                        }
+                        const inputTd = document.createElement('td');
+                        inputTd.innerText = d.input;
+                        dTr.append(inputTd);
+
+                        const resultTd = document.createElement('td');
+                        resultTd.innerText = d.result;
+                        resultTd.style.background = d.bg;
+                        if (d.info) {
+                            const a = document.createElement('a');
+                            a.innerText = " (...)";
+                            a.href = "javascript:void(0)";
+                            a.classList.add('info');
+                            a.onclick = () => {
+                                alert(d.info);
+                            };
+                            resultTd.append(a);
+                        }
+                        dTr.append(resultTd);
+
+                        [d.time, d.memory].forEach(val => {
+                            const td = document.createElement('td');
+                            td.innerText = val;
+                            dTr.append(td);
+                        });
+
+                        if (d.row_span > 0) {
+                            const scoreTd = document.createElement('td');
+                            scoreTd.rowSpan = d.row_span;
+                            scoreTd.style.background = d.bg;
+                            scoreTd.innerHTML = `<span style="font-weight: bold; font-size: large;">${d.score}</span> / ${d.full_score}`;
+                            dTr.append(scoreTd);
+                        }
+                        dTbody.append(dTr);
+                    });
+                    detailTable.append(dTbody);
+                    taskContainer.append(detailTable);
+                }
+                document.body.append(taskContainer);
+            });
+        });
+
+        const versionP = document.createElement('p');
+        versionP.innerText = data.version;
+        versionP.style.fontStyle = 'italic';
+        document.body.append(versionP);
+
+        renderTable();
+    </script>
+</body>
+</html>

--- a/src/component/exportutil/export_template.html
+++ b/src/component/exportutil/export_template.html
@@ -209,9 +209,18 @@
                 taskH3.innerText = `${data.i18n.task} ${data.task_names[j]}`;
                 taskContainer.append(taskH3);
 
-                const fileP = document.createElement('p');
-                fileP.innerText = t.file ? `${data.i18n.source_file}${t.file}` : data.i18n.no_source;
-                taskContainer.append(fileP);
+                if (t.info) {
+                    const fileP = document.createElement('p');
+                    fileP.innerText = t.info;
+                    taskContainer.append(fileP);
+                }
+
+                if (t.compile_message) {
+                    const msgPre = document.createElement('pre');
+                    msgPre.textContent = t.compile_message;
+                    msgPre.style.textAlign = 'left';
+                    taskContainer.append(msgPre);
+                }
 
                 if (t.details && t.details.length > 0) {
                     const detailTable = document.createElement('table');

--- a/src/component/exportutil/export_template.html
+++ b/src/component/exportutil/export_template.html
@@ -1,4 +1,7 @@
 <html>
+<head>
+    <meta charset="utf-8">
+</head>
 <body>
     <style>
         table {
@@ -50,6 +53,10 @@
         const hint = document.createElement('p');
         hint.innerText = data.i18n.hint;
         document.body.append(hint);
+
+        const topAnchor = document.createElement('a');
+        topAnchor.name = 'top';
+        document.body.append(topAnchor);
 
         const table = document.createElement('table');
         const thead = document.createElement('thead');
@@ -278,6 +285,13 @@
                 }
                 document.body.append(taskContainer);
             });
+
+            const returnP = document.createElement('p');
+            const returnA = document.createElement('a');
+            returnA.href = '#top';
+            returnA.innerText = data.i18n.return_to_top;
+            returnP.append(returnA);
+            document.body.append(returnP);
         });
 
         const versionP = document.createElement('p');

--- a/src/component/exportutil/export_template.html
+++ b/src/component/exportutil/export_template.html
@@ -110,29 +110,17 @@
 
         function updateHeaderIndicators() {
             const ths = thead.querySelectorAll('th');
-            ths.forEach((th, idx) => {
+            ths.forEach((th) => {
                 const indicator = th.querySelector('.sort-indicator');
                 if (!indicator) return;
 
-                if (idx >= 2) {
-                    const col = th.dataset.col;
-                    if (col === 'total' && sortState.key === 'total') {
-                        indicator.textContent = sortState.asc ? '▴' : '▾';
-                        indicator.style.visibility = 'visible';
-                    } else if (col === 'task') {
-                        const ti = parseInt(th.dataset.taskIndex, 10);
-                        if (sortState.key === 'task' && sortState.taskIndex === ti) {
-                            indicator.textContent = sortState.asc ? '▴' : '▾';
-                            indicator.style.visibility = 'visible';
-                        } else {
-                            indicator.style.visibility = 'hidden';
-                        }
-                    } else {
-                        indicator.style.visibility = 'hidden';
-                    }
-                } else {
-                    indicator.style.visibility = 'hidden';
-                }
+                const isActive =
+                    (sortState.key === 'total' && th.dataset.col === 'total') ||
+                    (sortState.key === 'task' && th.dataset.col === 'task' &&
+                     parseInt(th.dataset.taskIndex, 10) === sortState.taskIndex);
+
+                indicator.textContent = sortState.asc ? '▴' : '▾';
+                indicator.style.visibility = isActive ? 'visible' : 'hidden';
             });
         }
 
@@ -275,7 +263,12 @@
                             const scoreTd = document.createElement('td');
                             scoreTd.rowSpan = d.row_span;
                             scoreTd.style.background = d.bg;
-                            scoreTd.innerHTML = `<span style="font-weight: bold; font-size: large;">${d.score}</span> / ${d.full_score}`;
+                            const scoreSpan = document.createElement('span');
+                            scoreSpan.style.fontWeight = 'bold';
+                            scoreSpan.style.fontSize = 'large';
+                            scoreSpan.textContent = d.score;
+                            scoreTd.appendChild(scoreSpan);
+                            scoreTd.appendChild(document.createTextNode(` / ${d.full_score}`));
                             dTr.append(scoreTd);
                         }
                         dTbody.append(dTr);

--- a/src/component/exportutil/exportutil.cpp
+++ b/src/component/exportutil/exportutil.cpp
@@ -22,6 +22,9 @@
 
 #include <QApplication>
 #include <QFileDialog>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QMessageBox>
 #include <algorithm>
 #include <cmath>
@@ -29,246 +32,29 @@
 
 ExportUtil::ExportUtil(QObject *parent) : QObject(parent) {}
 
-const auto resultStateMap = []() {
-	QMap<ResultState, std::tuple<QString, QString, QString>> resMap;
-	for (int i = static_cast<int>(CorrectAnswer); i != static_cast<int>(LastResultState); i++) {
-		QString text, frColor, bgColor;
-		Settings::setTextAndColor(static_cast<ResultState>(i), text, frColor, bgColor);
-		resMap[static_cast<ResultState>(i)] = {text, frColor, bgColor};
-	}
-	return resMap;
-}();
-auto ExportUtil::getContestantHtmlCode(Contest *contest, Contestant *contestant, int num) -> QString {
-	QString htmlCode;
-	QList<Task *> taskList = contest->getTaskList();
-
-	for (int i = 0; i < taskList.size(); i++) {
-		htmlCode += QString(R"(<div id="c%1p%2"><p><span>)").arg(num).arg(i);
-		htmlCode += QString("%1 %2</span><br>").arg(tr("Task")).arg(taskList[i]->getProblemTitle());
-
-		if (! contestant->getCheckJudged(i)) {
-			htmlCode += QString("&nbsp;&nbsp;%1</p></div>").arg(tr("Not judged"));
-			continue;
-		}
-
-		if (taskList[i]->getTaskType() == Task::Traditional ||
-		    taskList[i]->getTaskType() == Task::Interaction ||
-		    taskList[i]->getTaskType() == Task::Communication ||
-		    taskList[i]->getTaskType() == Task::CommunicationExec) {
-			if (contestant->getCompileState(i) != CompileSuccessfully) {
-				switch (contestant->getCompileState(i)) {
-					case NoValidGraderFile:
-						htmlCode += QString("&nbsp;&nbsp;%1</p></div>")
-						                .arg(tr("Main grader (grader.*) cannot be found"));
-						break;
-
-					case NoValidSourceFile:
-						htmlCode +=
-						    QString("&nbsp;&nbsp;%1</p></div>").arg(tr("Cannot find valid source file"));
-						break;
-
-					case CompileTimeLimitExceeded:
-						htmlCode += QString("&nbsp;&nbsp;%1%2<br>")
-						                .arg(tr("Source file: "))
-						                .arg(contestant->getSourceFile(i));
-						htmlCode +=
-						    QString("&nbsp;&nbsp;%1</p></div>").arg(tr("Compile time limit exceeded"));
-						break;
-
-					case InvalidCompiler:
-						htmlCode += QString("&nbsp;&nbsp;%1</p></div>").arg(tr("Cannot run given compiler"));
-						break;
-
-					case CompileError:
-						htmlCode += QString("&nbsp;&nbsp;%1%2<br>")
-						                .arg(tr("Source file: "))
-						                .arg(contestant->getSourceFile(i));
-						htmlCode += QString("&nbsp;&nbsp;%1").arg(tr("Compile error"));
-
-						if (! contestant->getCompileMessage(i).isEmpty()) {
-							QString compileMessage = contestant->getCompileMessage(i);
-							compileMessage.replace("\r\n", "<br>");
-							compileMessage.replace("\n", "<br>");
-							compileMessage.replace("\r", "<br>");
-
-							if (compileMessage.endsWith("<br>"))
-								compileMessage.chop(4);
-
-							htmlCode += R"(<table border="1"  cellpadding="1">)";
-							htmlCode += "<tr><td style=\"padding: 0.5em; text-align: left;\"><code>";
-							htmlCode += compileMessage;
-							htmlCode += "</code></td></tr></table>";
-						}
-
-						htmlCode += "</p></div>";
-						break;
-
-					default:
-						break;
-				}
-
-				continue;
-			}
-
-			htmlCode +=
-			    QString("&nbsp;&nbsp;%1%2").arg(tr("Source file: ")).arg(contestant->getSourceFile(i));
-		}
-
-		htmlCode += "<table><tr>";
-		htmlCode += QString(R"(<th>%1</th>)").arg(tr("Test Case"));
-		htmlCode += QString(R"(<th>%1</th>)").arg(tr("Input File"));
-		htmlCode += QString(R"(<th>%1</th>)").arg(tr("Result"));
-		htmlCode += QString(R"(<th>%1</th>)").arg(tr("Time Used"));
-		htmlCode += QString(R"(<th>%1</th>)").arg(tr("Memory Used"));
-		htmlCode += QString(R"(<th>%1</th></tr>)").arg(tr("Score"));
-		QList<TestCase *> testCases = taskList[i]->getTestCaseList();
-		QList<QStringList> inputFiles = contestant->getInputFiles(i);
-		QList<QList<ResultState>> result = contestant->getResult(i);
-		QList<QStringList> message = contestant->getMessage(i);
-		QList<QList<int>> timeUsed = contestant->getTimeUsed(i);
-		QList<QList<qint64>> memoryUsed = contestant->getMemoryUsed(i);
-		QList<QList<int>> score = contestant->getScore(i);
-
-		for (int j = 0; j < inputFiles.size(); j++) {
-			for (int k = 0; k < inputFiles[j].size(); k++) {
-				htmlCode += "<tr>";
-
-				if (k == 0) {
-					if (score[j].size() == inputFiles[j].size())
-						htmlCode +=
-						    QString(R"(<td rowspan="%1">#%2</td>)").arg(inputFiles[j].size()).arg(j + 1);
-					else
-						htmlCode += QString(R"(<td rowspan="%1">#%2<br>%3:%4</td>)")
-						                .arg(inputFiles[j].size())
-						                .arg(j + 1)
-						                .arg(tr("Subtask Dependence Status"))
-						                .arg(statusRankingText(score[j].back()));
-				}
-
-				htmlCode += QString("<td>%1</td>").arg(inputFiles[j][k]);
-				QString text, bgColor, frColor;
-				Settings::setTextAndColor(result[j][k], text, frColor, bgColor);
-				htmlCode +=
-				    QString("<td class=\"result%2\">%1").arg(text).arg(static_cast<int>(result[j][k]));
-
-				if (! message[j][k].isEmpty()) {
-					QString tmp = message[j][k];
-					tmp.replace("\n", "\\n");
-					tmp.replace("\"", "\\&quot;");
-					htmlCode += QString("<a href=\"javascript:alert(&quot;%1&quot;)\"> (...)").arg(tmp);
-				}
-
-				htmlCode += "</td>";
-				htmlCode += "<td>";
-
-				if (timeUsed[j][k] != -1) {
-					htmlCode += QString("").asprintf("%.3lf s", double(timeUsed[j][k]) / 1000);
-				} else {
-					htmlCode += tr("Invalid");
-				}
-
-				htmlCode += "</td>";
-				htmlCode += "<td>";
-
-				if (memoryUsed[j][k] != -1) {
-					htmlCode += QString("").asprintf("%.3lf MiB", double(memoryUsed[j][k]) / 1024 / 1024);
-				} else {
-					htmlCode += tr("Invalid");
-				}
-
-				htmlCode += "</td>";
-
-				if (k == 0) {
-					int minv = 2147483647;
-					int maxv = testCases[j]->getFullScore();
-
-					for (int t = 0; t < inputFiles[j].size(); t++)
-						if (score[j][t] < minv)
-							minv = score[j][t];
-
-					QString bgClass = "zero-score";
-
-					if (minv >= maxv)
-						bgClass = "full-score";
-					else if (minv > 0)
-						bgClass = "partial-score";
-
-					htmlCode += QString(R"(<td rowspan="%1" class="%2"><span class="c">%3</span> / %4</td>)")
-					                .arg(inputFiles[j].size())
-					                .arg(bgClass)
-					                .arg(minv)
-					                .arg(maxv);
-				}
-
-				htmlCode += "</tr>";
-			}
-		}
-
-		htmlCode += "</table><br></p></div>";
-	}
-
-	htmlCode += QString("<p><a href=\"#top\">%1</a></p>").arg(tr("Return to top"));
-	return htmlCode;
-}
-/*
- * Generate the HTML code for the summary page
- * Might be difficult to maintain
- * Use Javascript to shrink the filesize
- */
-void ExportUtil::exportHtml(QWidget *widget, Contest *contest, const QString &fileName) {
+QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 	Settings settings;
 	contest->copySettings(settings);
 	ColorTheme colors = settings.getCurrentColorTheme();
 
-	QFile file(fileName);
-
-	if (! file.open(QFile::WriteOnly)) {
-		QMessageBox::warning(widget, tr("LemonLime"),
-		                     tr("Cannot open file %1").arg(QFileInfo(file).fileName()), QMessageBox::Ok);
-		return;
-	}
-
-	QApplication::setOverrideCursor(Qt::WaitCursor);
-	QTextStream out(&file);
 	QList<Contestant *> contestantList = contest->getContestantList();
 	QList<Task *> taskList = contest->getTaskList();
-	out << "<html><head>";
-	out << R"(<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />)";
+	int sfullScore = contest->getTotalScore();
 
-	// Style sheet
-	out << "<style type=\"text/css\">"
-	       "th, td {padding-left: 1em; padding-right: 1em; white-space: nowrap; "
-	       "text-align: center; verticle-align: middle;}"
-	       ".td-0 {border-style: none solid solid none; border-width: 1px 3px; border-color: #ccc;}"
-	       ".th-0 {border-style: none solid solid none; border-width: 3px 3px; border-color: #000;}"
-	       ".th-1 {border-style: none solid solid none; border-width: 3px 2px; border-color: #000;}"
-	       ".a-0 {color: black; text-decoration: none;} .c {font-weight: bold; font-size: large;}"
-	       ".td-2 {border-radius: 5px; font-weight: bold;}"
-	       ".td-3 {border-radius: 5px;}"
-	       ".full-score {background: rgb(192, 255, 192)}"
-	       ".partial-score {background: rgb(192, 255, 255)}"
-	       ".zero-score {background: rgb(255, 192, 192)}";
-	for (auto [k, v] : resultStateMap.toStdMap()) {
-		out << ".result" << static_cast<int>(k);
-		out << QString(" {color: %1;background: %2;}").arg(std::get<1>(v)).arg(std::get<2>(v));
-	}
-	out << "</style>";
-
-	out << "<title>" << contest->getContestTitle() << " : " << tr("Contest Result") << "</title>";
-	out << "</head><body>";
+	// Sort and rank
 	QList<std::pair<int, QString>> sortList;
 
 	for (auto &i : contestantList) {
 		int totalScore = i->getTotalScore();
 
 		if (totalScore != -1) {
-			sortList.append(std::make_pair(-totalScore, i->getContestantName()));
+			sortList.append(std::make_pair(totalScore, i->getContestantName()));
 		} else {
-			sortList.append(std::make_pair(1, i->getContestantName()));
+			sortList.append(std::make_pair(-1, i->getContestantName()));
 		}
 	}
 
-	std::sort(sortList.begin(), sortList.end());
+	std::sort(sortList.begin(), sortList.end(), std::greater<>());
 	QMap<QString, int> rankList;
 
 	for (int i = 0; i < sortList.size(); i++) {
@@ -279,77 +65,81 @@ void ExportUtil::exportHtml(QWidget *widget, Contest *contest, const QString &fi
 		}
 	}
 
-	QHash<Contestant *, int> loc;
+	// Top-level fields
+	QJsonObject root;
+	root["name"] = contest->getContestTitle();
+	root["version"] = QString("Lemonlime Version %1:%2").arg(LEMON_VERSION_STRING).arg(LEMON_VERSION_BUILD);
 
-	for (int i = 0; i < contestantList.size(); i++) {
-		loc.insert(contestantList[i], i);
+	// i18n
+	QJsonObject i18n;
+	i18n["rank_list"] = tr("Rank List");
+	i18n["hint"] = tr("Click names or task scores to jump to details. Judged By LemonLime");
+	i18n["rank"] = tr("Rank");
+	i18n["name"] = tr("Name");
+	i18n["total"] = tr("Total Score");
+	i18n["contestant"] = tr("Contestant");
+	i18n["task"] = tr("Task");
+	i18n["source_file"] = tr("Source file: ");
+	i18n["no_source"] = tr("Cannot find valid source file");
+	i18n["testcase"] = tr("Test Case");
+	i18n["input"] = tr("Input File");
+	i18n["result"] = tr("Result");
+	i18n["time"] = tr("Time Used");
+	i18n["memory"] = tr("Memory Used");
+	i18n["score"] = tr("Score");
+	root["i18n"] = i18n;
+
+	// task_names
+	QJsonArray taskNames;
+
+	for (auto &task : taskList) {
+		taskNames.append(task->getProblemTitle());
 	}
 
-	out << "<p><span class=\"d\">";
-	out << "<a name=\"top\"></a>" << contest->getContestTitle() << " : " << tr("Rank List") << "</span></p>";
-	out << "<p>" << tr("Click names or task scores to jump to details. Judged By LemonLime") << "</p>";
-	out << R"(<p><table cellpadding="1" style="border-style: solid;"><tr>)";
-	out << QString(R"(<th class="th-0" scope="col">%1</th>)").arg(tr("Rank"));
-	out << QString(R"(<th class="th-0" scope="col">%1</th>)").arg(tr("Name"));
-	out << QString(R"(<th class="th-1" scope="col">%1</th>)").arg(tr("Total Score"));
+	root["task_names"] = taskNames;
 
-	for (auto &i : taskList)
-		out << QString(R"(<th class="th-1" scope="col">%1</th>)").arg(i->getProblemTitle());
+	// contestants
+	QJsonArray contestantsArr;
 
-	out << "</tr>";
-	QList<int> fullScore;
-	int sfullScore = contest->getTotalScore();
+	for (int idx = 0; idx < contestantList.size(); idx++) {
+		Contestant *contestant = contestantList[idx];
+		QJsonObject cObj;
+		cObj["name"] = contestant->getContestantName();
+		cObj["rank"] = rankList[contestant->getContestantName()] + 1;
 
-	for (auto &i : taskList) {
-		fullScore.append(i->getTotalScore());
-	}
-
-	for (auto &i : sortList) {
-		Contestant *contestant = contest->getContestant(i.second);
-		out << "<tr>";
-		out << QString("<td class=\"td-0\">%1</td>").arg(rankList[contestant->getContestantName()] + 1);
-		out << QString(R"(<td class="td-0"><a href="#c%1" class="a-0">%2</a></td>)")
-		           .arg(loc[contestant])
-		           .arg(i.second);
 		int allScore = contestant->getTotalScore();
 
 		if (allScore >= 0) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+			cObj["total_score"] = allScore;
+
 			float h = NAN;
 			float s = NAN;
 			float l = NAN;
-#else
-			double h = NAN;
-			double s = NAN;
-			double l = NAN;
-#endif
+
 			colors.getColorGrand(allScore, sfullScore).getHslF(&h, &s, &l);
 			h *= 360, s *= 100, l *= 100;
-			out << QString("<td class=\"td-2\" style=\"background: hsl(%2,%3%,%4%); border: 2px solid "
-			               "hsl(%2,%3%,%5%);\">%1</td>")
-			           .arg(allScore)
-			           .arg(h)
-			           .arg(s)
-			           .arg(l)
-			           .arg(qMax(l - 20, 0.00));
+			cObj["total_bg"] = QString("%1, %2%, %3%").arg(h).arg(s).arg(l);
+			cObj["total_border"] = QString("%1, %2%, %3%").arg(h).arg(s).arg(qMax(l - 20, 0.00));
 		} else {
-			out << QString("<td class=\"td-2\">%1</td>").arg(tr("Invalid"));
+			cObj["total_score"] = 0;
+			cObj["total_bg"] = QString("0, 0%, 90%");
+			cObj["total_border"] = QString("0, 0%, 70%");
 		}
 
+		QJsonArray tasksArr;
+
 		for (int j = 0; j < taskList.size(); j++) {
+			QJsonObject tObj;
 			int score = contestant->getTaskScore(j);
 
-			if (score != -1) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+			if (score >= 0) {
+				tObj["score"] = score;
+
 				float h = NAN;
 				float s = NAN;
 				float l = NAN;
-#else
-				double h = NAN;
-				double s = NAN;
-				double l = NAN;
-#endif
-				QColor col = colors.getColorPer(score, fullScore[j]);
+
+				QColor col = colors.getColorPer(score, taskList[j]->getTotalScore());
 				col.getHslF(&h, &s, &l);
 
 				if (taskList[j]->getTaskType() != Task::AnswersOnly &&
@@ -362,318 +152,156 @@ void ExportUtil::exportHtml(QWidget *widget, Contest *contest, const QString &fi
 				}
 
 				h *= 360, s *= 100, l *= 100;
-				out << QString(
-				           R"(<td class="td-3" style="background: hsl(%2,%3%,%4%);"><a href="#c%5p%6" class="a-0">%1</a></td>)")
-				           .arg(score)
-				           .arg(h)
-				           .arg(s)
-				           .arg(l)
-				           .arg(loc[contestant])
-				           .arg(j);
+				tObj["bg"] = QString("%1, %2%, %3%").arg(h).arg(s).arg(l);
 			} else {
-				out << QString(R"(<td class="td-3"><a href="#c%2p%3" class="a-0">%1</a></td>)")
-				           .arg(tr("Invalid"))
-				           .arg(loc[contestant])
-				           .arg(j);
+				tObj["score"] = 0;
+				tObj["bg"] = QString("0, 0%, 90%");
 			}
-		}
-		out << "</tr>";
-	}
 
-	out << "</table></p>";
+			// source file
+			if (taskList[j]->getTaskType() == Task::Traditional ||
+			    taskList[j]->getTaskType() == Task::Interaction ||
+			    taskList[j]->getTaskType() == Task::Communication ||
+			    taskList[j]->getTaskType() == Task::CommunicationExec) {
+				if (contestant->getCheckJudged(j) &&
+				    contestant->getCompileState(j) == CompileSuccessfully) {
+					tObj["file"] = contestant->getSourceFile(j);
+				}
+			}
 
-	for (int i = 0; i < contestantList.size(); i++) {
-		out << QString("<a name=\"c%1\"><hr></a>").arg(i) << "<span class=\"d\">";
-		out << tr("Contestant: %1").arg(contestantList[i]->getContestantName()) << "</span>";
-		out << getContestantHtmlCode(contest, contestantList[i], i);
-	}
+			// details
+			bool isAnswersOnly = taskList[j]->getTaskType() == Task::AnswersOnly;
+			bool canShowDetails = contestant->getCheckJudged(j) &&
+			                      (isAnswersOnly || contestant->getCompileState(j) == CompileSuccessfully);
 
-	out << QString(R"(<footer><p><i>Lemonlime Version %1:%2</i></p></footer>)")
-	           .arg(LEMON_VERSION_STRING)
-	           .arg(LEMON_VERSION_BUILD);
+			if (canShowDetails) {
+				QList<TestCase *> testCases = taskList[j]->getTestCaseList();
+				QList<QStringList> inputFiles = contestant->getInputFiles(j);
+				QList<QList<ResultState>> result = contestant->getResult(j);
+				QList<QStringList> message = contestant->getMessage(j);
+				QList<QList<int>> timeUsed = contestant->getTimeUsed(j);
+				QList<QList<qint64>> memoryUsed = contestant->getMemoryUsed(j);
+				QList<QList<int>> score = contestant->getScore(j);
 
-	out << R"(
-	<script>
-		document.querySelectorAll("div[id^='c'] th").forEach(e=>e.classList.add("td-0"));
-		document.querySelectorAll("div[id^='c'] td").forEach(e=>e.classList.add("td-0"));
-		document.querySelectorAll("div[id^='c']>p>span").forEach(e=>{e.style.fontWeight="bold";e.style.fontSize="large";});
-		document.querySelectorAll("div[id^='c']>p>table").forEach(e=>e.style.border="solid");
-		document.querySelectorAll("div[id^='c']>p>table th").forEach(e=>e.setAttribute("scope","col"));
-	</script>
-	)";
-	out << "</body>";
-	out << "</html>";
-	QApplication::restoreOverrideCursor();
-	QMessageBox::information(widget, tr("LemonLime"), tr("Export is done"), QMessageBox::Ok);
-}
+				QJsonArray detailsArr;
 
-auto ExportUtil::getSmallerContestantHtmlCode(Contest *contest, Contestant *contestant) -> QString {
-	QString htmlCode;
-	QList<Task *> taskList = contest->getTaskList();
+				for (int jj = 0; jj < inputFiles.size(); jj++) {
+					for (int k = 0; k < inputFiles[jj].size(); k++) {
+						QJsonObject dObj;
 
-	for (int i = 0; i < taskList.size(); i++) {
-		htmlCode += "<p><span style=\"font-weight:bold; font-size:large;\">";
-		htmlCode += QString("%1 %2</span><br>").arg(tr("Task")).arg(taskList[i]->getProblemTitle());
+						if (k == 0) {
+							QString label = QString("#%1").arg(jj + 1);
 
-		if (! contestant->getCheckJudged(i)) {
-			htmlCode += QString("&nbsp;&nbsp;%1</p>").arg(tr("Not judged"));
-			continue;
-		}
+							if (score[jj].size() != inputFiles[jj].size()) {
+								label += QString("<br>%1:%2")
+								             .arg(tr("Subtask Dependence Status"))
+								             .arg(statusRankingText(score[jj].back()));
+							}
 
-		if (taskList[i]->getTaskType() == Task::Traditional ||
-		    taskList[i]->getTaskType() == Task::Interaction ||
-		    taskList[i]->getTaskType() == Task::Communication ||
-		    taskList[i]->getTaskType() == Task::CommunicationExec) {
-			if (contestant->getCompileState(i) != CompileSuccessfully) {
-				switch (contestant->getCompileState(i)) {
-					case NoValidGraderFile:
-						htmlCode += QString("&nbsp;&nbsp;%1</p></a>")
-						                .arg(tr("Main grader (grader.*) cannot be found"));
-						break;
-
-					case NoValidSourceFile:
-						htmlCode += QString("&nbsp;&nbsp;%1</p>").arg(tr("Cannot find valid source file"));
-						break;
-
-					case CompileTimeLimitExceeded:
-						htmlCode += QString("&nbsp;&nbsp;%1%2<br>")
-						                .arg(tr("Source file: "))
-						                .arg(contestant->getSourceFile(i));
-						htmlCode += QString("&nbsp;&nbsp;%1</p>").arg(tr("Compile time limit exceeded"));
-						break;
-
-					case InvalidCompiler:
-						htmlCode += QString("&nbsp;&nbsp;%1</p>").arg(tr("Cannot run given compiler"));
-						break;
-
-					case CompileError:
-						htmlCode += QString("&nbsp;&nbsp;%1%2<br>")
-						                .arg(tr("Source file: "))
-						                .arg(contestant->getSourceFile(i));
-						htmlCode += QString("&nbsp;&nbsp;%1").arg(tr("Compile error"));
-
-						if (! contestant->getCompileMessage(i).isEmpty()) {
-							QString compileMessage = contestant->getCompileMessage(i);
-							compileMessage.replace("\r\n", "<br>");
-							compileMessage.replace("\n", "<br>");
-							compileMessage.replace("\r", "<br>");
-
-							if (compileMessage.endsWith("<br>"))
-								compileMessage.chop(4);
-
-							htmlCode += R"(<table border="1" cellpadding="1">)";
-							htmlCode += "<tr><td style=\"padding: 0.5em; text-align: left;\"><code>";
-							htmlCode += compileMessage;
-							htmlCode += "</code></td></tr></table>";
+							dObj["label"] = label;
+							dObj["row_span"] = inputFiles[jj].size();
+						} else {
+							dObj["label"] = QString("");
+							dObj["row_span"] = 0;
 						}
 
-						htmlCode += "</p>";
-						break;
+						dObj["input"] = inputFiles[jj][k];
 
-					default:
-						break;
+						QString text;
+						QString frColor;
+						QString bgColor;
+						Settings::setTextAndColor(result[jj][k], text, frColor, bgColor);
+						dObj["result"] = text;
+
+						dObj["bg"] = bgColor;
+
+						if (timeUsed[jj][k] != -1) {
+							dObj["time"] = QString("").asprintf("%.3lf s", double(timeUsed[jj][k]) / 1000);
+						} else {
+							dObj["time"] = tr("Invalid");
+						}
+
+						if (memoryUsed[jj][k] != -1) {
+							dObj["memory"] =
+							    QString("").asprintf("%.3lf MB", double(memoryUsed[jj][k]) / 1024 / 1024);
+						} else {
+							dObj["memory"] = tr("Invalid");
+						}
+
+						if (k == 0) {
+							int minv = 2147483647;
+							int maxv = testCases[jj]->getFullScore();
+
+							for (int t = 0; t < inputFiles[jj].size(); t++)
+								if (score[jj][t] < minv)
+									minv = score[jj][t];
+
+							dObj["score"] = minv;
+							dObj["full_score"] = maxv;
+						} else {
+							dObj["score"] = 0;
+							dObj["full_score"] = 0;
+						}
+
+						if (!message[jj][k].isEmpty()) {
+							dObj["info"] = message[jj][k];
+						}
+
+						detailsArr.append(dObj);
+					}
 				}
 
-				continue;
+				tObj["details"] = detailsArr;
 			}
 
-			htmlCode +=
-			    QString("&nbsp;&nbsp;%1%2").arg(tr("Source file: ")).arg(contestant->getSourceFile(i));
+			tasksArr.append(tObj);
 		}
 
-		htmlCode += R"(<table border="1"  cellpadding="1"><tr>)";
-		htmlCode += QString("<th scope=\"col\">%1</th>").arg(tr("Test Case"));
-		htmlCode += QString("<th scope=\"col\">%1</th>").arg(tr("Input File"));
-		htmlCode += QString("<th scope=\"col\">%1</th>").arg(tr("Result"));
-		htmlCode += QString("<th scope=\"col\">%1</th>").arg(tr("Time Used"));
-		htmlCode += QString("<th scope=\"col\">%1</th>").arg(tr("Memory Used"));
-		htmlCode += QString("<th scope=\"col\">%1</th></tr>").arg(tr("Score"));
-		QList<TestCase *> testCases = taskList[i]->getTestCaseList();
-		QList<QStringList> inputFiles = contestant->getInputFiles(i);
-		QList<QList<ResultState>> result = contestant->getResult(i);
-		QList<QStringList> message = contestant->getMessage(i);
-		QList<QList<int>> timeUsed = contestant->getTimeUsed(i);
-		QList<QList<qint64>> memoryUsed = contestant->getMemoryUsed(i);
-		QList<QList<int>> score = contestant->getScore(i);
-
-		for (int j = 0; j < inputFiles.size(); j++) {
-			for (int k = 0; k < inputFiles[j].size(); k++) {
-				htmlCode += "<tr>";
-
-				if (k == 0) {
-					if (score[j].size() == inputFiles[j].size())
-						htmlCode +=
-						    QString("<td rowspan=\"%1\">#%2</td>").arg(inputFiles[j].size()).arg(j + 1);
-					else
-						htmlCode += QString("<td rowspan=\"%1\">#%2<br>%3:%4</td>")
-						                .arg(inputFiles[j].size())
-						                .arg(j + 1)
-						                .arg(tr("Subtask Dependence Status"))
-						                .arg(statusRankingText(score[j].back()));
-				}
-
-				htmlCode += QString("<td>%1</td>").arg(inputFiles[j][k]);
-				QString text;
-				QString bgColor;
-				QString frColor;
-				Settings::setTextAndColor(result[j][k], text, frColor, bgColor);
-				htmlCode += QString("<td>%1").arg(text);
-
-				if (! message[j][k].isEmpty()) {
-					QString tmp = message[j][k];
-					tmp.replace("\n", "\\n");
-					tmp.replace("\"", "\\&quot;");
-					htmlCode += QString("<a href=\"javascript:alert(&quot;%1&quot;)\"> (...)").arg(tmp);
-				}
-
-				htmlCode += "</td>";
-				htmlCode += "<td>";
-
-				if (timeUsed[j][k] != -1) {
-					htmlCode += QString("").asprintf("%.3lf s", double(timeUsed[j][k]) / 1000);
-				} else {
-					htmlCode += tr("Invalid");
-				}
-
-				htmlCode += "</td>";
-				htmlCode += "<td>";
-
-				if (memoryUsed[j][k] != -1) {
-					htmlCode += QString("").asprintf("%.3lf MiB", double(memoryUsed[j][k]) / 1024 / 1024);
-				} else {
-					htmlCode += tr("Invalid");
-				}
-
-				htmlCode += "</td>";
-
-				if (k == 0) {
-					int minv = 2147483647;
-					int maxv = testCases[j]->getFullScore();
-
-					for (int t = 0; t < inputFiles[j].size(); t++)
-						if (score[j][t] < minv)
-							minv = score[j][t];
-
-					htmlCode += QString(R"(<td rowspan="%1"><span class="c">%2</span> / %3</td>)")
-					                .arg(inputFiles[j].size())
-					                .arg(minv)
-					                .arg(maxv);
-				}
-
-				htmlCode += "</tr>";
-			}
-		}
-
-		htmlCode += "</table><br></p>";
+		cObj["tasks"] = tasksArr;
+		contestantsArr.append(cObj);
 	}
 
-	htmlCode += QString("<p><a href=\"#top\">%1</a></p>").arg(tr("Return to top"));
-	return htmlCode;
+	root["contestants"] = contestantsArr;
+	return root;
 }
 
-void ExportUtil::exportSmallerHtml(QWidget *widget, Contest *contest, const QString &fileName) {
+void ExportUtil::exportHtml(QWidget *widget, Contest *contest, const QString &fileName) {
 	QFile file(fileName);
 
-	if (! file.open(QFile::WriteOnly)) {
+	if (!file.open(QFile::WriteOnly)) {
 		QMessageBox::warning(widget, tr("LemonLime"),
 		                     tr("Cannot open file %1").arg(QFileInfo(file).fileName()), QMessageBox::Ok);
 		return;
 	}
 
 	QApplication::setOverrideCursor(Qt::WaitCursor);
+
+	// Read template from Qt resource
+	QFile templateFile(":/export/export_template.html");
+
+	if (!templateFile.open(QFile::ReadOnly | QFile::Text)) {
+		QApplication::restoreOverrideCursor();
+		QMessageBox::warning(widget, tr("LemonLime"), tr("Cannot read export template"), QMessageBox::Ok);
+		return;
+	}
+
+	QString htmlTemplate = templateFile.readAll();
+	templateFile.close();
+
+	// Build JSON data
+	QJsonObject jsonData = buildExportJson(contest);
+	QJsonDocument doc(jsonData);
+	QString jsonStr = doc.toJson(QJsonDocument::Compact);
+
+	// Replace placeholder with actual data
+	htmlTemplate.replace("%%DATA%%", jsonStr);
+
+	// Write output
 	QTextStream out(&file);
-	QList<Contestant *> contestantList = contest->getContestantList();
-	QList<Task *> taskList = contest->getTaskList();
-	out << "<html><head>";
-	out << R"(<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />)";
-	out << "<style type=\"text/css\">th, td {padding-left: 1em; padding-right: 1em; white-space: nowrap; "
-	       "text-align: center; verticle-align: middle;} .a {border-style: none solid solid none; "
-	       "border-width: 1px 3px; border-color: #ccc;} .b {border-style: none solid solid none; "
-	       "border-width: 3px 3px; border-color: #000;} .c {font-weight: bold; font-size: large;} "
-	       ".d {font-size:x-large; font-weight:bold;} .e {font-size: small;} .f {font-weight: bold;}"
-	       ".g {border-style: none solid solid none; border-width: 3px 2px; border-color: #000;}</style>";
-	out << "<title>" << contest->getContestTitle() << " : " << tr("Contest Result") << "</title>";
-	out << "</head><body>";
-	QList<std::pair<int, QString>> sortList;
+	out << htmlTemplate;
+	out.flush();
+	file.close();
 
-	for (auto &i : contestantList) {
-		int totalScore = i->getTotalScore();
-
-		if (totalScore != -1) {
-			sortList.append(std::make_pair(-totalScore, i->getContestantName()));
-		} else {
-			sortList.append(std::make_pair(1, i->getContestantName()));
-		}
-	}
-
-	std::sort(sortList.begin(), sortList.end());
-	QMap<QString, int> rankList;
-
-	for (int i = 0; i < sortList.size(); i++) {
-		if (i > 0 && sortList[i].first == sortList[i - 1].first) {
-			rankList.insert(sortList[i].second, rankList[sortList[i - 1].second]);
-		} else {
-			rankList.insert(sortList[i].second, i);
-		}
-	}
-
-	QHash<Contestant *, int> loc;
-
-	for (int i = 0; i < contestantList.size(); i++) {
-		loc.insert(contestantList[i], i);
-	}
-
-	out << "<p><span class=\"d\">";
-	out << "<a name=\"top\"></a>" << contest->getContestTitle() << " : " << tr("Rank List") << "</span></p>";
-	out << "<p class=\"e\">" << tr("Judged By LemonLime") << "</p>";
-	out << R"(<p><table border="1" cellpadding="1"><tr>)";
-	out << QString("<th scope=\"col\">%1</th>").arg(tr("Rank"));
-	out << QString("<th scope=\"col\">%1</th>").arg(tr("Name"));
-	out << QString("<th scope=\"col\">%1</th>").arg(tr("Total Score"));
-
-	for (auto &i : taskList)
-		out << QString("<th scope=\"col\">%1</th>").arg(i->getProblemTitle());
-
-	out << QString("</tr>");
-	QList<int> fullScore;
-
-	for (auto &i : taskList) {
-		int a = i->getTotalScore();
-		fullScore.append(a);
-	}
-
-	for (auto &i : sortList) {
-		Contestant *contestant = contest->getContestant(i.second);
-		out << QString("<tr><td>%1</td>").arg(rankList[contestant->getContestantName()] + 1);
-		out << QString("<td><a href=\"#c%1\">%2</a></td>").arg(loc[contestant]).arg(i.second);
-		int allScore = contestant->getTotalScore();
-
-		if (allScore != -1) {
-			out << QString("<td class=\"f\">%1</td>").arg(allScore);
-		} else {
-			out << QString("<td class=\"f\">%1</td>").arg(tr("Invalid"));
-		}
-
-		for (int j = 0; j < taskList.size(); j++) {
-			int score = contestant->getTaskScore(j);
-
-			if (score != -1) {
-				out << QString("<td>%1</td>").arg(score);
-			} else {
-				out << QString("<td>%1</td>").arg(tr("Invalid"));
-			}
-		}
-	}
-
-	out << "</table></p>";
-
-	for (int i = 0; i < contestantList.size(); i++) {
-		out << QString("<a name=\"c%1\"><hr><a>").arg(i) << "<span class=\"d\">";
-		out << tr("Contestant: %1").arg(contestantList[i]->getContestantName()) << "</span>";
-		out << getSmallerContestantHtmlCode(contest, contestantList[i]);
-	}
-
-	out << "</body></html>";
 	QApplication::restoreOverrideCursor();
 	QMessageBox::information(widget, tr("LemonLime"), tr("Export is done"), QMessageBox::Ok);
 }
@@ -681,7 +309,7 @@ void ExportUtil::exportSmallerHtml(QWidget *widget, Contest *contest, const QStr
 void ExportUtil::exportCsv(QWidget *widget, Contest *contest, const QString &fileName) {
 	QFile file(fileName);
 
-	if (! file.open(QFile::WriteOnly)) {
+	if (!file.open(QFile::WriteOnly)) {
 		QMessageBox::warning(widget, tr("LemonLime"),
 		                     tr("Cannot open file %1").arg(QFileInfo(file).fileName()), QMessageBox::Ok);
 		return;
@@ -697,13 +325,13 @@ void ExportUtil::exportCsv(QWidget *widget, Contest *contest, const QString &fil
 		int totalScore = i->getTotalScore();
 
 		if (totalScore != -1) {
-			sortList.append(std::make_pair(-totalScore, i->getContestantName()));
+			sortList.append(std::make_pair(totalScore, i->getContestantName()));
 		} else {
-			sortList.append(std::make_pair(1, i->getContestantName()));
+			sortList.append(std::make_pair(-1, i->getContestantName()));
 		}
 	}
 
-	std::sort(sortList.begin(), sortList.end());
+	std::sort(sortList.begin(), sortList.end(), std::greater<>());
 	QMap<QString, int> rankList;
 
 	for (int i = 0; i < sortList.size(); i++) {
@@ -752,103 +380,12 @@ void ExportUtil::exportCsv(QWidget *widget, Contest *contest, const QString &fil
 		}
 	}
 
+	out.flush();
+	file.close();
+
 	QApplication::restoreOverrideCursor();
 	QMessageBox::information(widget, tr("LemonLime"), tr("Export is done"), QMessageBox::Ok);
 }
-
-#ifdef ENABLE_XLS_EXPORT
-void ExportUtil::exportXls(QWidget *widget, Contest *contest, const QString &fileName) {
-
-	if (QFile(fileName).exists()) {
-		if (! QFile(fileName).remove()) {
-			QMessageBox::warning(widget, tr("LemonLime"),
-			                     tr("Cannot open file %1").arg(QFileInfo(fileName).fileName()),
-			                     QMessageBox::Ok);
-			return;
-		}
-	}
-
-	QApplication::setOverrideCursor(Qt::WaitCursor);
-	QList<Contestant *> contestantList = contest->getContestantList();
-	QList<Task *> taskList = contest->getTaskList();
-	QList<std::pair<int, QString>> sortList;
-
-	for (int i = 0; i < contestantList.size(); i++) {
-		int totalScore = contestantList[i]->getTotalScore();
-
-		if (totalScore != -1) {
-			sortList.append(std::make_pair(-totalScore, contestantList[i]->getContestantName()));
-		} else {
-			sortList.append(std::make_pair(1, contestantList[i]->getContestantName()));
-		}
-	}
-
-	std::sort(sortList.begin(), sortList.end());
-	QMap<QString, int> rankList;
-
-	for (int i = 0; i < sortList.size(); i++) {
-		if (i > 0 && sortList[i].first == sortList[i - 1].first) {
-			rankList.insert(sortList[i].second, rankList[sortList[i - 1].second]);
-		} else {
-			rankList.insert(sortList[i].second, i);
-		}
-	}
-
-	QMap<Contestant *, int> loc;
-
-	for (int i = 0; i < contestantList.size(); i++) {
-		loc.insert(contestantList[i], i);
-	}
-
-	QAxObject *excel = new QAxObject("Excel.Application", widget);
-	QAxObject *workbook = excel->querySubObject("Workbooks")->querySubObject("Add");
-	QAxObject *sheet = workbook->querySubObject("ActiveSheet");
-	sheet->setProperty("Name", QDate::currentDate().toString("yyyy-MM-dd"));
-	sheet->querySubObject("Cells(int, int)", 1, 1)->setProperty("Value", tr("Rank"));
-	sheet->querySubObject("Cells(int, int)", 1, 2)->setProperty("Value", tr("Name"));
-
-	for (int i = 0; i < taskList.size(); i++)
-		sheet->querySubObject("Cells(int, int)", 1, 3 + i)
-		    ->setProperty("Value", taskList[i]->getProblemTitle());
-
-	sheet->querySubObject("Cells(int, int)", 1, 3 + taskList.size())->setProperty("Value", tr("Total Score"));
-
-	for (int i = 0; i < taskList.size() + 3; i++)
-		sheet->querySubObject("Cells(int, int)", 1, i + 1)->querySubObject("Font")->setProperty("Bold", true);
-
-	for (int i = 0; i < sortList.size(); i++) {
-		Contestant *contestant = contest->getContestant(sortList[i].second);
-		sheet->querySubObject("Cells(int, int)", 2 + i, 1)
-		    ->setProperty("Value", rankList[contestant->getContestantName()] + 1);
-		sheet->querySubObject("Cells(int, int)", 2 + i, 2)->setProperty("Value", sortList[i].second);
-
-		for (int j = 0; j < taskList.size(); j++) {
-			int score = contestant->getTaskScore(j);
-
-			if (score != -1) {
-				sheet->querySubObject("Cells(int, int)", 2 + i, 3 + j)->setProperty("Value", score);
-			} else {
-				sheet->querySubObject("Cells(int, int)", 2 + i, 3 + j)->setProperty("Value", tr("Invalid"));
-			}
-		}
-
-		int score = contestant->getTotalScore();
-
-		if (score != -1) {
-			sheet->querySubObject("Cells(int, int)", 2 + i, 3 + taskList.size())->setProperty("Value", score);
-		} else {
-			sheet->querySubObject("Cells(int, int)", 2 + i, 3 + taskList.size())
-			    ->setProperty("Value", tr("Invalid"));
-		}
-	}
-
-	workbook->dynamicCall("SaveAs(const QString&, int)", QDir::toNativeSeparators(fileName), -4143);
-	excel->dynamicCall("Quit()");
-	delete excel;
-	QApplication::restoreOverrideCursor();
-	QMessageBox::information(widget, tr("LemonLime"), tr("Export is done"), QMessageBox::Ok);
-}
-#endif
 
 void ExportUtil::exportResult(QWidget *widget, Contest *contest) {
 	QList<Contestant *> contestantList = contest->getContestantList();
@@ -865,31 +402,16 @@ void ExportUtil::exportResult(QWidget *widget, Contest *contest) {
 		return;
 	}
 
-	QString filter = tr("HTML Document (*.html *.htm);;CSV (*.csv)");
-#ifdef ENABLE_XLS_EXPORT
-	QAxObject *excel = new QAxObject("Excel.Application", widget);
-
-	if (! excel->isNull())
-		filter = filter + tr(";;Excel Workbook (*.xls)");
-
-	delete excel;
-#endif
+	QString filter = tr("HTML Document (*.html);;CSV (*.csv)");
 	QString fileName = QFileDialog::getSaveFileName(
 	    widget, tr("Export Result"), QDir::currentPath() + QDir::separator() + "result.html", filter);
 
 	if (fileName.isEmpty())
 		return;
-	// TODO: refactor
+
 	if (QFileInfo(fileName).suffix() == "html")
 		exportHtml(widget, contest, fileName);
 
-	if (QFileInfo(fileName).suffix() == "htm")
-		exportSmallerHtml(widget, contest, fileName);
-
 	if (QFileInfo(fileName).suffix() == "csv")
 		exportCsv(widget, contest, fileName);
-#ifdef ENABLE_XLS_EXPORT
-	if (QFileInfo(fileName).suffix() == "xls")
-		exportXls(widget, contest, fileName);
-#endif
 }

--- a/src/component/exportutil/exportutil.cpp
+++ b/src/component/exportutil/exportutil.cpp
@@ -41,7 +41,6 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 	QList<Task *> taskList = contest->getTaskList();
 	int sfullScore = contest->getTotalScore();
 
-	// Sort and rank
 	QList<std::pair<int, QString>> sortList;
 
 	for (auto &i : contestantList) {
@@ -65,12 +64,10 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 		}
 	}
 
-	// Top-level fields
 	QJsonObject root;
 	root["name"] = contest->getContestTitle();
 	root["version"] = QString("Lemonlime Version %1:%2").arg(LEMON_VERSION_STRING).arg(LEMON_VERSION_BUILD);
 
-	// i18n
 	QJsonObject i18n;
 	i18n["rank_list"] = tr("Rank List");
 	i18n["hint"] = tr("Click names or task scores to jump to details. Judged By LemonLime");
@@ -90,7 +87,6 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 	i18n["return_to_top"] = tr("Return to top");
 	root["i18n"] = i18n;
 
-	// task_names
 	QJsonArray taskNames;
 
 	for (auto &task : taskList) {
@@ -99,7 +95,6 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 
 	root["task_names"] = taskNames;
 
-	// contestants
 	QJsonArray contestantsArr;
 
 	for (int idx = 0; idx < contestantList.size(); idx++) {
@@ -159,7 +154,6 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 				tObj["bg"] = QString("0, 0%, 90%");
 			}
 
-			// source file
 			if (taskList[j]->getTaskType() == Task::Traditional ||
 			    taskList[j]->getTaskType() == Task::Interaction ||
 			    taskList[j]->getTaskType() == Task::Communication ||
@@ -169,7 +163,6 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 				}
 			}
 
-			// details
 			bool isAnswersOnly = taskList[j]->getTaskType() == Task::AnswersOnly;
 			bool canShowDetails = contestant->getCheckJudged(j) &&
 			                      (isAnswersOnly || contestant->getCompileState(j) == CompileSuccessfully);
@@ -223,7 +216,7 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 
 						if (memoryUsed[jj][k] != -1) {
 							dObj["memory"] =
-							    QString("").asprintf("%.3lf MB", double(memoryUsed[jj][k]) / 1024 / 1024);
+							    QString("").asprintf("%.3lf MiB", double(memoryUsed[jj][k]) / 1024 / 1024);
 						} else {
 							dObj["memory"] = tr("Invalid");
 						}
@@ -276,7 +269,6 @@ void ExportUtil::exportHtml(QWidget *widget, Contest *contest, const QString &fi
 
 	QApplication::setOverrideCursor(Qt::WaitCursor);
 
-	// Read template from Qt resource
 	QFile templateFile(":/export/export_template.html");
 
 	if (! templateFile.open(QFile::ReadOnly | QFile::Text)) {
@@ -288,15 +280,12 @@ void ExportUtil::exportHtml(QWidget *widget, Contest *contest, const QString &fi
 	QString htmlTemplate = templateFile.readAll();
 	templateFile.close();
 
-	// Build JSON data
 	QJsonObject jsonData = buildExportJson(contest);
 	QJsonDocument doc(jsonData);
 	QString jsonStr = doc.toJson(QJsonDocument::Compact);
 
-	// Replace placeholder with actual data
 	htmlTemplate.replace("%%DATA%%", jsonStr);
 
-	// Write output
 	QTextStream out(&file);
 	out << htmlTemplate;
 	out.flush();

--- a/src/component/exportutil/exportutil.cpp
+++ b/src/component/exportutil/exportutil.cpp
@@ -87,6 +87,7 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 	i18n["time"] = tr("Time Used");
 	i18n["memory"] = tr("Memory Used");
 	i18n["score"] = tr("Score");
+	i18n["return_to_top"] = tr("Return to top");
 	root["i18n"] = i18n;
 
 	// task_names
@@ -163,8 +164,7 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 			    taskList[j]->getTaskType() == Task::Interaction ||
 			    taskList[j]->getTaskType() == Task::Communication ||
 			    taskList[j]->getTaskType() == Task::CommunicationExec) {
-				if (contestant->getCheckJudged(j) &&
-				    contestant->getCompileState(j) == CompileSuccessfully) {
+				if (contestant->getCheckJudged(j) && contestant->getCompileState(j) == CompileSuccessfully) {
 					tObj["file"] = contestant->getSourceFile(j);
 				}
 			}
@@ -243,7 +243,7 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 							dObj["full_score"] = 0;
 						}
 
-						if (!message[jj][k].isEmpty()) {
+						if (! message[jj][k].isEmpty()) {
 							dObj["info"] = message[jj][k];
 						}
 
@@ -268,7 +268,7 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 void ExportUtil::exportHtml(QWidget *widget, Contest *contest, const QString &fileName) {
 	QFile file(fileName);
 
-	if (!file.open(QFile::WriteOnly)) {
+	if (! file.open(QFile::WriteOnly)) {
 		QMessageBox::warning(widget, tr("LemonLime"),
 		                     tr("Cannot open file %1").arg(QFileInfo(file).fileName()), QMessageBox::Ok);
 		return;
@@ -279,7 +279,7 @@ void ExportUtil::exportHtml(QWidget *widget, Contest *contest, const QString &fi
 	// Read template from Qt resource
 	QFile templateFile(":/export/export_template.html");
 
-	if (!templateFile.open(QFile::ReadOnly | QFile::Text)) {
+	if (! templateFile.open(QFile::ReadOnly | QFile::Text)) {
 		QApplication::restoreOverrideCursor();
 		QMessageBox::warning(widget, tr("LemonLime"), tr("Cannot read export template"), QMessageBox::Ok);
 		return;
@@ -309,7 +309,7 @@ void ExportUtil::exportHtml(QWidget *widget, Contest *contest, const QString &fi
 void ExportUtil::exportCsv(QWidget *widget, Contest *contest, const QString &fileName) {
 	QFile file(fileName);
 
-	if (!file.open(QFile::WriteOnly)) {
+	if (! file.open(QFile::WriteOnly)) {
 		QMessageBox::warning(widget, tr("LemonLime"),
 		                     tr("Cannot open file %1").arg(QFileInfo(file).fileName()), QMessageBox::Ok);
 		return;
@@ -340,12 +340,6 @@ void ExportUtil::exportCsv(QWidget *widget, Contest *contest, const QString &fil
 		} else {
 			rankList.insert(sortList[i].second, i);
 		}
-	}
-
-	QHash<Contestant *, int> loc;
-
-	for (int i = 0; i < contestantList.size(); i++) {
-		loc.insert(contestantList[i], i);
 	}
 
 	out << "\"" << tr("Rank") << "\"" << "," << "\"" << tr("Name") << "\"" << ",";

--- a/src/component/exportutil/exportutil.cpp
+++ b/src/component/exportutil/exportutil.cpp
@@ -47,13 +47,13 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 		int totalScore = i->getTotalScore();
 
 		if (totalScore != -1) {
-			sortList.append(std::make_pair(totalScore, i->getContestantName()));
+			sortList.append(std::make_pair(-totalScore, i->getContestantName()));
 		} else {
-			sortList.append(std::make_pair(-1, i->getContestantName()));
+			sortList.append(std::make_pair(1, i->getContestantName()));
 		}
 	}
 
-	std::sort(sortList.begin(), sortList.end(), std::greater<>());
+	std::sort(sortList.begin(), sortList.end());
 	QMap<QString, int> rankList;
 
 	for (int i = 0; i < sortList.size(); i++) {
@@ -95,8 +95,8 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 
 	QJsonArray contestantsArr;
 
-	for (int idx = 0; idx < contestantList.size(); idx++) {
-		Contestant *contestant = contestantList[idx];
+	for (int idx = 0; idx < sortList.size(); idx++) {
+		Contestant *contestant = contest->getContestant(sortList[idx].second);
 		QJsonObject cObj;
 		cObj["name"] = contestant->getContestantName();
 		cObj["rank"] = rankList[contestant->getContestantName()] + 1;
@@ -349,13 +349,13 @@ void ExportUtil::exportCsv(QWidget *widget, Contest *contest, const QString &fil
 		int totalScore = i->getTotalScore();
 
 		if (totalScore != -1) {
-			sortList.append(std::make_pair(totalScore, i->getContestantName()));
+			sortList.append(std::make_pair(-totalScore, i->getContestantName()));
 		} else {
-			sortList.append(std::make_pair(-1, i->getContestantName()));
+			sortList.append(std::make_pair(1, i->getContestantName()));
 		}
 	}
 
-	std::sort(sortList.begin(), sortList.end(), std::greater<>());
+	std::sort(sortList.begin(), sortList.end());
 	QMap<QString, int> rankList;
 
 	for (int i = 0; i < sortList.size(); i++) {

--- a/src/component/exportutil/exportutil.cpp
+++ b/src/component/exportutil/exportutil.cpp
@@ -172,15 +172,15 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 							info = tr("Cannot find valid source file");
 							break;
 						case CompileTimeLimitExceeded:
-							info = tr("Source file: ") + contestant->getSourceFile(j) +
-							       QString(", ") + tr("Compile time limit exceeded");
+							info = tr("Source file: ") + contestant->getSourceFile(j) + QString(", ") +
+							       tr("Compile time limit exceeded");
 							break;
 						case InvalidCompiler:
 							info = tr("Cannot run given compiler");
 							break;
 						case CompileError:
-							info = tr("Source file: ") + contestant->getSourceFile(j) +
-							       QString(", ") + tr("Compile error");
+							info = tr("Source file: ") + contestant->getSourceFile(j) + QString(", ") +
+							       tr("Compile error");
 							break;
 						default:
 							break;
@@ -191,8 +191,7 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 					tObj["info"] = info;
 				}
 
-				if (contestant->getCheckJudged(j) &&
-				    contestant->getCompileState(j) == CompileError &&
+				if (contestant->getCheckJudged(j) && contestant->getCompileState(j) == CompileError &&
 				    ! contestant->getCompileMessage(j).isEmpty()) {
 					tObj["compile_message"] = contestant->getCompileMessage(j);
 				}

--- a/src/component/exportutil/exportutil.cpp
+++ b/src/component/exportutil/exportutil.cpp
@@ -163,7 +163,7 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 				} else {
 					switch (contestant->getCompileState(j)) {
 						case CompileSuccessfully:
-							info = tr("Source file: ") + contestant->getSourceFile(j);
+							info = tr("Source file: %1").arg(contestant->getSourceFile(j));
 							break;
 						case NoValidGraderFile:
 							info = tr("Main grader (grader.*) cannot be found");
@@ -172,15 +172,13 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 							info = tr("Cannot find valid source file");
 							break;
 						case CompileTimeLimitExceeded:
-							info = tr("Source file: ") + contestant->getSourceFile(j) + QString(", ") +
-							       tr("Compile time limit exceeded");
+							info = tr("Source file: %1, Compile time limit exceeded").arg(contestant->getSourceFile(j));
 							break;
 						case InvalidCompiler:
 							info = tr("Cannot run given compiler");
 							break;
 						case CompileError:
-							info = tr("Source file: ") + contestant->getSourceFile(j) + QString(", ") +
-							       tr("Compile error");
+							info = tr("Source file: %1, Compile error").arg(contestant->getSourceFile(j));
 							break;
 						default:
 							break;

--- a/src/component/exportutil/exportutil.cpp
+++ b/src/component/exportutil/exportutil.cpp
@@ -172,7 +172,8 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 							info = tr("Cannot find valid source file");
 							break;
 						case CompileTimeLimitExceeded:
-							info = tr("Source file: %1, Compile time limit exceeded").arg(contestant->getSourceFile(j));
+							info = tr("Source file: %1, Compile time limit exceeded")
+							           .arg(contestant->getSourceFile(j));
 							break;
 						case InvalidCompiler:
 							info = tr("Cannot run given compiler");

--- a/src/component/exportutil/exportutil.cpp
+++ b/src/component/exportutil/exportutil.cpp
@@ -76,8 +76,6 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 	i18n["total"] = tr("Total Score");
 	i18n["contestant"] = tr("Contestant");
 	i18n["task"] = tr("Task");
-	i18n["source_file"] = tr("Source file: ");
-	i18n["no_source"] = tr("Cannot find valid source file");
 	i18n["testcase"] = tr("Test Case");
 	i18n["input"] = tr("Input File");
 	i18n["result"] = tr("Result");
@@ -158,9 +156,48 @@ QJsonObject ExportUtil::buildExportJson(Contest *contest) {
 			    taskList[j]->getTaskType() == Task::Interaction ||
 			    taskList[j]->getTaskType() == Task::Communication ||
 			    taskList[j]->getTaskType() == Task::CommunicationExec) {
-				if (contestant->getCheckJudged(j) && contestant->getCompileState(j) == CompileSuccessfully) {
-					tObj["file"] = contestant->getSourceFile(j);
+				QString info;
+
+				if (! contestant->getCheckJudged(j)) {
+					info = tr("Not judged");
+				} else {
+					switch (contestant->getCompileState(j)) {
+						case CompileSuccessfully:
+							info = tr("Source file: ") + contestant->getSourceFile(j);
+							break;
+						case NoValidGraderFile:
+							info = tr("Main grader (grader.*) cannot be found");
+							break;
+						case NoValidSourceFile:
+							info = tr("Cannot find valid source file");
+							break;
+						case CompileTimeLimitExceeded:
+							info = tr("Source file: ") + contestant->getSourceFile(j) +
+							       QString(", ") + tr("Compile time limit exceeded");
+							break;
+						case InvalidCompiler:
+							info = tr("Cannot run given compiler");
+							break;
+						case CompileError:
+							info = tr("Source file: ") + contestant->getSourceFile(j) +
+							       QString(", ") + tr("Compile error");
+							break;
+						default:
+							break;
+					}
 				}
+
+				if (! info.isEmpty()) {
+					tObj["info"] = info;
+				}
+
+				if (contestant->getCheckJudged(j) &&
+				    contestant->getCompileState(j) == CompileError &&
+				    ! contestant->getCompileMessage(j).isEmpty()) {
+					tObj["compile_message"] = contestant->getCompileMessage(j);
+				}
+			} else if (! contestant->getCheckJudged(j)) {
+				tObj["info"] = tr("Not judged");
 			}
 
 			bool isAnswersOnly = taskList[j]->getTaskType() == Task::AnswersOnly;

--- a/src/component/exportutil/exportutil.h
+++ b/src/component/exportutil/exportutil.h
@@ -11,11 +11,8 @@
 //
 
 #include "base/LemonType.hpp"
+#include <QJsonObject>
 #include <QObject>
-
-#ifdef ENABLE_XLS_EXPORT
-#include <QAxObject>
-#endif
 
 class Contest;
 class Contestant;
@@ -27,14 +24,9 @@ class ExportUtil : public QObject {
 	static void exportResult(QWidget *, Contest *);
 
   private:
-	static QString getContestantHtmlCode(Contest *, Contestant *, int);
-	static QString getSmallerContestantHtmlCode(Contest *, Contestant *);
+	static QJsonObject buildExportJson(Contest *);
 	static void exportHtml(QWidget *, Contest *, const QString &);
-	static void exportSmallerHtml(QWidget *, Contest *, const QString &);
 	static void exportCsv(QWidget *, Contest *, const QString &);
-#ifdef ENABLE_XLS_EXPORT
-	static void exportXls(QWidget *, Contest *, const QString &);
-#endif
   signals:
 
   public slots:

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -716,6 +716,18 @@
         <translation></translation>
     </message>
     <message>
+        <source>Source file: %1</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Source file: %1, Compile time limit exceeded</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Source file: %1, Compile error</source>
+        <translation></translation>
+    </message>
+    <message>
         <source>Compile time limit exceeded</source>
         <translation></translation>
     </message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -729,6 +729,18 @@
         <translation>源程序： </translation>
     </message>
     <message>
+        <source>Source file: %1</source>
+        <translation>源程序：%1</translation>
+    </message>
+    <message>
+        <source>Source file: %1, Compile time limit exceeded</source>
+        <translation>源程序：%1，编译超时</translation>
+    </message>
+    <message>
+        <source>Source file: %1, Compile error</source>
+        <translation>源程序：%1，编译错误</translation>
+    </message>
+    <message>
         <source>Compile time limit exceeded</source>
         <translation>编译超时</translation>
     </message>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -729,6 +729,18 @@
         <translation>源程式： </translation>
     </message>
     <message>
+        <source>Source file: %1</source>
+        <translation>源程式：%1</translation>
+    </message>
+    <message>
+        <source>Source file: %1, Compile time limit exceeded</source>
+        <translation>源程式：%1，編譯超時</translation>
+    </message>
+    <message>
+        <source>Source file: %1, Compile error</source>
+        <translation>源程式：%1，編譯錯誤</translation>
+    </message>
+    <message>
         <source>Compile time limit exceeded</source>
         <translation>編譯超時</translation>
     </message>


### PR DESCRIPTION
## 这个 pr 做了什么

- 将 HTML 导出从 C++ 拼接 HTML 字符串重写为 JSON + 模板方案：C++ 端通过 `buildExportJson()` 构建数据 JSON，嵌入 `export_template.html` 的 `%%DATA%%` 占位符，由浏览器端 JS 完成渲染
- 移除 XLS 导出
- 移除 .htm 导出
- 对导出支持了按每道题排序

测试了 CSP 2025 J，并添加了一个题答题作为测试：[result.html](https://github.com/user-attachments/files/28432194/result.html)

感觉，打开会慢一点，不过还可以接受。

（上面这个有 bug，编译错误会显示成未评测，最新的可以看：[result.html](https://github.com/user-attachments/files/28679035/result.html)）