### PR TITLE
fix(ci): resolve GitHub Actions warnings

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'

--- a/.github/workflows/macos-qt6.yml
+++ b/.github/workflows/macos-qt6.yml
@@ -30,14 +30,11 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qt_ver }}
-          cached: ${{ steps.MacosCacheQt.outputs.cache-hit }}
+          cache: true
 
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - name: macOS - ${{ matrix.qt_version }} - Build preparation - Install Packages
-        run: |
-          brew install ninja pkg-config
       - name: build macos
         run: |
           cmake . \

--- a/.github/workflows/windows-qt6.yml
+++ b/.github/workflows/windows-qt6.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: Install Python 3.12 version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           architecture: x64
@@ -52,23 +52,15 @@ jobs:
         run: git submodule update --init
       # =========================================================================================================
       - name: Install MSVC compiler
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
-          # 14.1 is for vs2017, 14.2 is vs2019, following the upstream vcpkg build from Qv2ray-deps repo
           arch: x64
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v5
-        with:
-          path: ../Qt
-          key: QtCache-${{ matrix.platform }}-x64-${{ matrix.qt_version }}
       - name: Installing Qt - x64
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qt_version }}
           arch: ${{ matrix.qtarch }}
-          mirror: "http://mirrors.ocf.berkeley.edu/qt/"
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cache: true
           setup-python: "false"
           modules: "qtactiveqt"
 


### PR DESCRIPTION
GitHub Actions 已宣布弃用 Node.js 20 运行时，当前 CI 中多个 Action 仍运行在 Node.js 20 上，导致产生弃用警告。

更新到 Node.js 24，同时由于 `ilammy/msvc-dev-cmd` 已不再维护，不支持 Node.js 24，故更换为 `TheMrMilchmann/setup-msvc-dev@v4.0.0`。

移除了 `install-qt-action@v4` 的 `mirror` 和 `cached`，这些已经过时，并启用 `cache: true`。

删除 `brew install ninja pkg-config` 步骤，这些已经预装不需要额外下载