### PR TITLE
fix(linux-static-qt6.yml): Fix linux ci error

### DIFF
--- a/.github/workflows/linux-static-qt6.yml
+++ b/.github/workflows/linux-static-qt6.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Install Build Essentials
         run: |
           apt update
-          apt install -y build-essential git perl cmake ninja-build wget
+          apt install -y build-essential git perl ninja-build wget
+          wget -q https://github.com/Kitware/CMake/releases/download/v3.30.6/cmake-3.30.6-linux-x86_64.tar.gz -O /tmp/cmake.tar.gz
+          tar -xzf /tmp/cmake.tar.gz -C /opt
+          echo "/opt/cmake-3.30.6-linux-x86_64/bin" >> $GITHUB_PATH
       - name: Checking out sources
         uses: actions/checkout@v6
         with:
@@ -51,7 +54,7 @@ jobs:
       - name: Install build dependencies
         run: |
           apt update
-          apt install -y build-essential ninja-build cmake pkgconf bash
+          apt install -y build-essential ninja-build pkgconf bash
           apt install -y libgl1-mesa-dev libglu1-mesa-dev
           apt install -y libfontconfig1-dev libfreetype6-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev  libxcb-xinerama0-dev libxkbcommon-dev libxkbcommon-x11-dev
           apt install -y libharfbuzz-dev libsm-dev libdrm-dev

--- a/.github/workflows/linux-static-qt6.yml
+++ b/.github/workflows/linux-static-qt6.yml
@@ -57,7 +57,7 @@ jobs:
           apt install -y build-essential ninja-build pkgconf bash
           apt install -y libgl1-mesa-dev libglu1-mesa-dev
           apt install -y libfontconfig1-dev libfreetype6-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev  libxcb-xinerama0-dev libxkbcommon-dev libxkbcommon-x11-dev
-          apt install -y libharfbuzz-dev libsm-dev libdrm-dev
+          apt install -y libharfbuzz-dev libsm-dev libdrm-dev libbrotli-dev
           apt install -y '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
           apt install -y bubblewrap
       - name: Install Qt

--- a/.github/workflows/linux-static-qt6.yml
+++ b/.github/workflows/linux-static-qt6.yml
@@ -43,10 +43,6 @@ jobs:
       - name: Install Build Essentials
         run: |
           apt update
-          apt install -y software-properties-common
-          add-apt-repository ppa:savoury1/build-tools
-          apt update
-          apt upgrade -y
           apt install -y build-essential git perl cmake ninja-build wget
       - name: Checking out sources
         uses: actions/checkout@v6


### PR DESCRIPTION
2026-05-12 linux 构建 ci 引用的一个 PPA 更新了一个包：<https://launchpad.net/~savoury1/+archive/ubuntu/build-tools/+packages?field.name_filter=freetype&field.status_filter=published&field.series_filter=focal>

导致 ci 在下载依赖阶段出现错误。引入这个 PPA 的初衷是安装新的 cmake，所以我们改为手动下载较新的 cmake，而不是引入 PPA 的方式。

同时手动下载了 `libbrotli-dev`，防止 `Qt6Network` 找不到。