### PR TITLE
feat(check_format.yml): update ci, use `pachadotdev/clang-format` with clang-format v21

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -3,26 +3,12 @@ name: "Check Clang Format"
 on: [push, pull_request]
 
 jobs:
-  format:
+  formatting-check:
     name: "Check Clang Format"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: "Install clang-format"
-        run: |
-          sudo apt-get update
-          sudo apt-get install clang-format
-      - name: "Format Codes"
-        run: clang-format -i src/*.cpp src/*.h src/**/*.cpp src/**/*.h src/**/**/*.cpp src/**/**/*.h src/**/*.hpp
-      - name: Check diff
-        run: git diff --exit-code HEAD
-      - name: Create Pull Request
-        if: failure()
-        uses: peter-evans/create-pull-request@v8
+      - uses: jidicula/clang-format-action@v4.18.0
         with:
-          commit-message: "style: format codes"
-          title: "Format codes for ${{ github.ref }}"
-          labels: "style"
-          assignees: "${{ github.actor }}"
-          reviewers: "${{ github.actor }}"
-          branch: "auto-pr/clang-format/${{ github.ref }}"
+          clang-format-version: "21"
+          check-path: "src"

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -3,12 +3,13 @@ name: "Check Clang Format"
 on: [push, pull_request]
 
 jobs:
-  formatting-check:
+  format:
     name: "Check Clang Format"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: jidicula/clang-format-action@v4.18.0
+      - uses: pachadotdev/clang-format@v1.1
         with:
-          clang-format-version: "21"
-          check-path: "src"
+          version: "21"
+          auto-commit: true
+          commit-message: "style: format codes"

--- a/src/base/LemonBaseApplication.hpp
+++ b/src/base/LemonBaseApplication.hpp
@@ -18,8 +18,8 @@ namespace Lemon {
 	  public:
 		LemonBaseApplication(int &argc, char *argv[])
 		    : SingleApplication(argc, argv, true, User | ExcludeAppPath | ExcludeAppVersion),
-		      LemonApplicationInterface(){};
-		virtual ~LemonBaseApplication(){};
+		      LemonApplicationInterface() {};
+		virtual ~LemonBaseApplication() {};
 
 		virtual bool Initialize() final;
 

--- a/src/core/processrunner.cpp
+++ b/src/core/processrunner.cpp
@@ -16,8 +16,8 @@
 ProcessRunner::ProcessRunner(ProcessRunnerConfig cfg, const std::atomic<bool> &stop)
     : config(std::move(cfg)), stopFlag(stop) {}
 
-auto ProcessRunner::create(ProcessRunnerConfig config,
-                           const std::atomic<bool> &stopFlag) -> std::unique_ptr<ProcessRunner> {
+auto ProcessRunner::create(ProcessRunnerConfig config, const std::atomic<bool> &stopFlag)
+    -> std::unique_ptr<ProcessRunner> {
 #ifdef Q_OS_WIN32
 	return std::make_unique<WinProcessRunner>(std::move(config), stopFlag);
 #else

--- a/src/lemon.cpp
+++ b/src/lemon.cpp
@@ -879,8 +879,8 @@ void LemonLime::addTaskWithScoreScale(const QString &title,
 	}
 }
 
-auto LemonLime::compareFileName(const std::pair<QString, QString> &a,
-                                const std::pair<QString, QString> &b) -> bool {
+auto LemonLime::compareFileName(const std::pair<QString, QString> &a, const std::pair<QString, QString> &b)
+    -> bool {
 	return (a.first.length() < b.first.length()) ||
 	       (a.first.length() == b.first.length() && QString::localeAwareCompare(a.first, b.first) < 0);
 }

--- a/src/statisticsbrowser.cpp
+++ b/src/statisticsbrowser.cpp
@@ -33,8 +33,8 @@ StatisticsBrowser::~StatisticsBrowser() { delete ui; }
 
 void StatisticsBrowser::setContest(Contest *contest) { curContest = contest; }
 
-auto StatisticsBrowser::getScoreNormalChart(const QMap<int, int> &scoreCount, int listSize,
-                                            int totalScore) -> QString {
+auto StatisticsBrowser::getScoreNormalChart(const QMap<int, int> &scoreCount, int listSize, int totalScore)
+    -> QString {
 	QString buffer = "";
 	long long overallScoreSum = 0;
 	double scoreDiscrim = 0;
@@ -230,8 +230,8 @@ auto StatisticsBrowser::getTestcaseScoreChart(QList<TestCase *> testCaseList,
 	return buffer;
 }
 
-auto StatisticsBrowser::checkValid(QList<Task *> taskList,
-                                   const QList<Contestant *> &contestantList) -> bool {
+auto StatisticsBrowser::checkValid(QList<Task *> taskList, const QList<Contestant *> &contestantList)
+    -> bool {
 	for (auto *i : taskList) {
 		for (auto *j : i->getTestCaseList()) {
 			if (j->getInputFiles().length() != j->getOutputFiles().length())


### PR DESCRIPTION
现在使用的 clang-format 18 有bug：https://github.com/llvm/llvm-project/issues/79834 ，影响了一部分文件的格式化，更新了 ci，并且支持在 pr 中自动 format