### PR TITLE
feat(filelineedit): add browse button

### DIFF
--- a/assets/pics/document-open.svg
+++ b/assets/pics/document-open.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#232629;
+      }
+      </style>
+  </defs>
+ <path 
+     style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="M 3 2 L 3 14 L 6 14 L 6 13 L 4 13 L 4 3 L 9 3 L 9 6 L 12 6 L 12 8 L 13 8 L 13 5 L 10 2 L 9 2 L 3 2 z M 7 8 L 7 14 L 13 14 L 13 9 L 11 9 L 10 8 L 7 8 z M 8 10 L 12 10 L 12 13 L 8 13 L 8 10 z "
+     class="ColorScheme-Text"/>
+</svg>

--- a/resource.qrc
+++ b/resource.qrc
@@ -31,6 +31,7 @@
         <file alias="deletecell.svg">assets/pics/deletecell.svg</file>
         <file alias="document-close.svg">assets/pics/document-close.svg</file>
         <file alias="document-export.svg">assets/pics/document-export.svg</file>
+        <file alias="document-open.svg">assets/pics/document-open.svg</file>
         <file alias="document-new.svg">assets/pics/document-new.svg</file>
         <file alias="document-save.svg">assets/pics/document-save.svg</file>
         <file alias="globe.svg">assets/pics/globe.svg</file>

--- a/src/filelineedit.cpp
+++ b/src/filelineedit.cpp
@@ -81,5 +81,5 @@ void FileLineEdit::browse() {
 		return;
 	}
 
-	setText(relPath);
+	setText(QDir::toNativeSeparators(relPath));
 }

--- a/src/filelineedit.cpp
+++ b/src/filelineedit.cpp
@@ -10,8 +10,17 @@
 #include "filelineedit.h"
 //
 #include "base/settings.h"
+//
+#include <QAction>
+#include <QFileDialog>
+#include <QMessageBox>
 
-FileLineEdit::FileLineEdit(QWidget *parent) : QLineEdit(parent) { completer = nullptr; }
+FileLineEdit::FileLineEdit(QWidget *parent) : QLineEdit(parent) {
+	completer = nullptr;
+	QAction *browseAction = addAction(QIcon(":/icon/document-open.svg"), QLineEdit::TrailingPosition);
+	browseAction->setToolTip(tr("Browse..."));
+	connect(browseAction, &QAction::triggered, this, &FileLineEdit::browse);
+}
 
 void FileLineEdit::getFiles(const QString &curDir, const QString &prefix, QStringList &files) {
 	QDir dir(curDir);
@@ -53,4 +62,24 @@ void FileLineEdit::refreshFileList() {
 	delete completer;
 	completer = new QCompleter(files, this);
 	setCompleter(completer);
+}
+
+void FileLineEdit::browse() {
+	QDir dataDir(QDir::currentPath());
+	dataDir.mkpath(Settings::dataPath());
+	dataDir.cd(Settings::dataPath());
+	QString filePath = QFileDialog::getOpenFileName(this, tr("Choose File"), dataDir.absolutePath());
+
+	if (filePath.isEmpty())
+		return;
+
+	QString relPath = dataDir.relativeFilePath(filePath);
+
+	if (relPath.startsWith("..") || QDir::isAbsolutePath(relPath)) {
+		QMessageBox::warning(this, tr("Warning"), tr("Please select a file inside the data directory."),
+		                     QMessageBox::Close);
+		return;
+	}
+
+	setText(relPath);
 }

--- a/src/filelineedit.h
+++ b/src/filelineedit.h
@@ -27,6 +27,7 @@ class FileLineEdit : public QLineEdit {
 	QCompleter *completer;
 	QStringList nameFilters;
 	QDir::Filters filters;
+	void browse();
 
   public slots:
 	void refreshFileList();

--- a/translations/en_US.ts
+++ b/translations/en_US.ts
@@ -2694,4 +2694,23 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
 </context>
+<context>
+    <name>FileLineEdit</name>
+    <message>
+        <source>Browse...</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Please select a file inside the data directory.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Choose File</source>
+        <translation></translation>
+    </message>
+</context>
 </TS>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2728,4 +2728,23 @@ p, li { white-space: pre-wrap; }
         <translation>新建</translation>
     </message>
 </context>
+<context>
+    <name>FileLineEdit</name>
+    <message>
+        <source>Browse...</source>
+        <translation>浏览...</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <source>Please select a file inside the data directory.</source>
+        <translation>请选择 data 目录内的文件。</translation>
+    </message>
+    <message>
+        <source>Choose File</source>
+        <translation>选择文件</translation>
+    </message>
+</context>
 </TS>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -2728,4 +2728,23 @@ p, li { white-space: pre-wrap; }
         <translation>新建</translation>
     </message>
 </context>
+<context>
+    <name>FileLineEdit</name>
+    <message>
+        <source>Browse...</source>
+        <translation>瀏覽...</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <source>Please select a file inside the data directory.</source>
+        <translation>請選擇 data 目錄內的檔案。</translation>
+    </message>
+    <message>
+        <source>Choose File</source>
+        <translation>選擇檔案</translation>
+    </message>
+</context>
 </TS>


### PR DESCRIPTION
在 filelineedit 输入框控件右侧添加一个浏览按钮，可以选择文件。

Windows 下 和 linux 下的斜杠也能正确切换：

<img width="625" height="405" alt="image" src="https://github.com/user-attachments/assets/8d5a8653-ee81-4d45-b959-db4ef1ec5c09" />

如果是在右边添加三个点的按钮，感觉要改 ui，有点懒？所以就这么处理了。
